### PR TITLE
Add Colab and Binder badges to notebooks and markdown files

### DIFF
--- a/book/analytics/buildings.ipynb
+++ b/book/analytics/buildings.ipynb
@@ -5,6 +5,15 @@
    "id": "0",
    "metadata": {},
    "source": [
+    "[![image](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/giswqs/duckdb-spatial/blob/main/book/analytics/buildings.ipynb)\n",
+    "[![image](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/giswqs/duckdb-spatial/main?urlpath=lab/tree/book/analytics/buildings.ipynb)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1",
+   "metadata": {},
+   "source": [
     "# Analyzing Global Building Footprints\n",
     "\n",
     "## Introduction\n",
@@ -19,7 +28,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "1",
+   "id": "2",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -29,7 +38,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "2",
+   "id": "3",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -39,7 +48,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "3",
+   "id": "4",
    "metadata": {},
    "source": [
     "## Installing and Loading Extensions"
@@ -48,7 +57,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "4",
+   "id": "5",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -61,7 +70,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "5",
+   "id": "6",
    "metadata": {},
    "source": [
     "## Exploring Available Data\n",
@@ -72,7 +81,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "6",
+   "id": "7",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -83,7 +92,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "7",
+   "id": "8",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -93,7 +102,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "8",
+   "id": "9",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -107,7 +116,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "9",
+   "id": "10",
    "metadata": {},
    "source": [
     "### Counting the Complete Dataset"
@@ -116,7 +125,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "10",
+   "id": "11",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -128,7 +137,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "11",
+   "id": "12",
    "metadata": {},
    "source": [
     "### Visualizing Buildings in 3D"
@@ -137,7 +146,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "12",
+   "id": "13",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -154,7 +163,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "13",
+   "id": "14",
    "metadata": {},
    "source": [
     "## Regional Analysis with Bounding Box Filtering\n",
@@ -165,7 +174,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "14",
+   "id": "15",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -195,7 +204,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "15",
+   "id": "16",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -204,7 +213,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "16",
+   "id": "17",
    "metadata": {},
    "source": [
     "### Exporting Regional Data"
@@ -213,7 +222,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "17",
+   "id": "18",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -222,7 +231,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "18",
+   "id": "19",
    "metadata": {},
    "source": [
     "### Basic Statistics"
@@ -231,7 +240,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "19",
+   "id": "20",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -242,7 +251,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "20",
+   "id": "21",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -261,7 +270,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "21",
+   "id": "22",
    "metadata": {},
    "source": [
     "### Building Size Distribution"
@@ -270,7 +279,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "22",
+   "id": "23",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -293,7 +302,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "23",
+   "id": "24",
    "metadata": {},
    "source": [
     "### Spatial Sampling and Visualization"
@@ -302,7 +311,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "24",
+   "id": "25",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -320,7 +329,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "25",
+   "id": "26",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -339,7 +348,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "26",
+   "id": "27",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -348,7 +357,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "27",
+   "id": "28",
    "metadata": {},
    "source": [
     "### Visualizing Buildings Directly from DuckDB"
@@ -357,7 +366,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "28",
+   "id": "29",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -382,7 +391,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "29",
+   "id": "30",
    "metadata": {},
    "source": [
     "### Data-Driven Styling by Building Area"
@@ -391,7 +400,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "30",
+   "id": "31",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -440,7 +449,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "31",
+   "id": "32",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -449,7 +458,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "32",
+   "id": "33",
    "metadata": {},
    "source": [
     "## Multi-Region Comparison\n",
@@ -460,7 +469,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "33",
+   "id": "34",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -472,7 +481,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "34",
+   "id": "35",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -482,7 +491,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "35",
+   "id": "36",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -491,7 +500,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "36",
+   "id": "37",
    "metadata": {},
    "source": [
     "### Loading County Boundaries"
@@ -500,7 +509,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "37",
+   "id": "38",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -515,7 +524,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "38",
+   "id": "39",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -525,7 +534,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "39",
+   "id": "40",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -558,7 +567,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "40",
+   "id": "41",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -577,7 +586,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "41",
+   "id": "42",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -594,7 +603,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "42",
+   "id": "43",
    "metadata": {},
    "source": [
     "## Data Source Filtering and Quality Assessment"
@@ -603,7 +612,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "43",
+   "id": "44",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -626,7 +635,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "44",
+   "id": "45",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -637,7 +646,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "45",
+   "id": "46",
    "metadata": {},
    "source": [
     "### Filtering by Data Source Quality"
@@ -646,7 +655,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "46",
+   "id": "47",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -666,7 +675,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "47",
+   "id": "48",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -675,7 +684,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "48",
+   "id": "49",
    "metadata": {},
    "source": [
     "### Visualizing Data Source Distribution"
@@ -684,7 +693,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "49",
+   "id": "50",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -729,7 +738,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "50",
+   "id": "51",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -738,7 +747,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "51",
+   "id": "52",
    "metadata": {},
    "source": [
     "## Grid-Based Spatial Aggregation\n",
@@ -749,7 +758,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "52",
+   "id": "53",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -761,7 +770,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "53",
+   "id": "54",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -770,7 +779,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "54",
+   "id": "55",
    "metadata": {},
    "source": [
     "### Generating a Regular Grid"
@@ -779,7 +788,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "55",
+   "id": "56",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -791,7 +800,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "56",
+   "id": "57",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -801,7 +810,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "57",
+   "id": "58",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -810,7 +819,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "58",
+   "id": "59",
    "metadata": {},
    "source": [
     "### Loading Grid into DuckDB"
@@ -819,7 +828,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "59",
+   "id": "60",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -832,7 +841,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "60",
+   "id": "61",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -841,7 +850,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "61",
+   "id": "62",
    "metadata": {},
    "source": [
     "### Performing Spatial Aggregation"
@@ -850,7 +859,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "62",
+   "id": "63",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -881,7 +890,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "63",
+   "id": "64",
    "metadata": {},
    "source": [
     "### Visualizing Grid Aggregation Results"
@@ -890,7 +899,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "64",
+   "id": "65",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -904,7 +913,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "65",
+   "id": "66",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -923,7 +932,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "66",
+   "id": "67",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -932,7 +941,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "67",
+   "id": "68",
    "metadata": {},
    "source": [
     "## Aggregating Building Data with H3 Hexagonal Grids\n",
@@ -945,7 +954,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "68",
+   "id": "69",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -957,7 +966,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "69",
+   "id": "70",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -967,7 +976,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "70",
+   "id": "71",
    "metadata": {},
    "source": [
     "### Choosing Appropriate H3 Resolutions\n",
@@ -978,7 +987,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "71",
+   "id": "72",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1003,7 +1012,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "72",
+   "id": "73",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1021,7 +1030,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "73",
+   "id": "74",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1034,7 +1043,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "74",
+   "id": "75",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1044,7 +1053,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "75",
+   "id": "76",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1054,7 +1063,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "76",
+   "id": "77",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1065,7 +1074,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "77",
+   "id": "78",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1074,7 +1083,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "78",
+   "id": "79",
    "metadata": {},
    "source": [
     "### Visualizing H3 Aggregations"
@@ -1083,7 +1092,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "79",
+   "id": "80",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1103,7 +1112,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "80",
+   "id": "81",
    "metadata": {},
    "source": [
     "### 3D Visualization with Extruded Hexagons"
@@ -1112,7 +1121,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "81",
+   "id": "82",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1134,7 +1143,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "82",
+   "id": "83",
    "metadata": {},
    "source": [
     "### Advanced H3 Operations"
@@ -1143,7 +1152,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "83",
+   "id": "84",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1163,7 +1172,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "84",
+   "id": "85",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1177,7 +1186,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "85",
+   "id": "86",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1186,7 +1195,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "86",
+   "id": "87",
    "metadata": {},
    "source": [
     "### When to Use H3 vs. Other Aggregation Methods\n",
@@ -1201,14 +1210,14 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "87",
+   "id": "88",
    "metadata": {},
    "outputs": [],
    "source": []
   },
   {
    "cell_type": "markdown",
-   "id": "88",
+   "id": "89",
    "metadata": {},
    "source": [
     "### Exercise 2: Multi-Resolution Grid Analysis"
@@ -1217,14 +1226,14 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "89",
+   "id": "90",
    "metadata": {},
    "outputs": [],
    "source": []
   },
   {
    "cell_type": "markdown",
-   "id": "90",
+   "id": "91",
    "metadata": {},
    "source": [
     "### Exercise 3: Cross-Regional Building Size Analysis"
@@ -1233,14 +1242,14 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "91",
+   "id": "92",
    "metadata": {},
    "outputs": [],
    "source": []
   },
   {
    "cell_type": "markdown",
-   "id": "92",
+   "id": "93",
    "metadata": {},
    "source": [
     "### Exercise 4: Data Source Quality Analysis"
@@ -1249,14 +1258,14 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "93",
+   "id": "94",
    "metadata": {},
    "outputs": [],
    "source": []
   },
   {
    "cell_type": "markdown",
-   "id": "94",
+   "id": "95",
    "metadata": {},
    "source": [
     "### Exercise 5: Building Height Analysis"
@@ -1265,7 +1274,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "95",
+   "id": "96",
    "metadata": {},
    "outputs": [],
    "source": []

--- a/book/analytics/buildings.md
+++ b/book/analytics/buildings.md
@@ -10,6 +10,10 @@ kernelspec:
   language: python
   name: python3
 ---
+
+[![image](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/giswqs/duckdb-spatial/blob/main/book/analytics/buildings.ipynb)
+[![image](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/giswqs/duckdb-spatial/main?urlpath=lab/tree/book/analytics/buildings.ipynb)
+
 # Analyzing Global Building Footprints
 
 ## Introduction

--- a/book/analytics/dashboards.ipynb
+++ b/book/analytics/dashboards.ipynb
@@ -5,6 +5,15 @@
    "id": "0",
    "metadata": {},
    "source": [
+    "[![image](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/giswqs/duckdb-spatial/blob/main/book/analytics/dashboards.ipynb)\n",
+    "[![image](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/giswqs/duckdb-spatial/main?urlpath=lab/tree/book/analytics/dashboards.ipynb)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1",
+   "metadata": {},
+   "source": [
     "# Developing Interactive Dashboards with Voilà and Solara\n",
     "\n",
     "## Introduction\n",
@@ -29,7 +38,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "1",
+   "id": "2",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -39,7 +48,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "2",
+   "id": "3",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -49,7 +58,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "3",
+   "id": "4",
    "metadata": {},
    "source": [
     "## Introduction to Hugging Face Spaces\n",
@@ -62,7 +71,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "4",
+   "id": "5",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -71,7 +80,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "5",
+   "id": "6",
    "metadata": {},
    "source": [
     "### Logging in to Hugging Face\n",
@@ -96,7 +105,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "6",
+   "id": "7",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -114,7 +123,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "7",
+   "id": "8",
    "metadata": {},
    "source": [
     "#### Initializing the DuckDB Connection"
@@ -123,7 +132,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "8",
+   "id": "9",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -138,7 +147,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "9",
+   "id": "10",
    "metadata": {},
    "source": [
     "#### Loading the Building Data"
@@ -147,7 +156,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "10",
+   "id": "11",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -160,7 +169,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "11",
+   "id": "12",
    "metadata": {},
    "source": [
     "#### Creating the User Interface Controls"
@@ -169,7 +178,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "12",
+   "id": "13",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -211,7 +220,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "13",
+   "id": "14",
    "metadata": {},
    "source": [
     "#### Implementing the Query Logic"
@@ -220,7 +229,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "14",
+   "id": "15",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -287,7 +296,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "15",
+   "id": "16",
    "metadata": {},
    "source": [
     "#### Wiring Up the Interface"
@@ -296,7 +305,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "16",
+   "id": "17",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -317,7 +326,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "17",
+   "id": "18",
    "metadata": {},
    "source": [
     "#### How Voilà Transforms This Notebook\n",
@@ -365,7 +374,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "18",
+   "id": "19",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -397,7 +406,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "19",
+   "id": "20",
    "metadata": {},
    "source": [
     "#### Understanding the Component Structure\n",
@@ -414,7 +423,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "20",
+   "id": "21",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -456,7 +465,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "21",
+   "id": "22",
    "metadata": {},
    "source": [
     "#### Understanding the Buildings Page\n",

--- a/book/analytics/dashboards.md
+++ b/book/analytics/dashboards.md
@@ -10,6 +10,10 @@ kernelspec:
   language: python
   name: python3
 ---
+
+[![image](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/giswqs/duckdb-spatial/blob/main/book/analytics/dashboards.ipynb)
+[![image](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/giswqs/duckdb-spatial/main?urlpath=lab/tree/book/analytics/dashboards.ipynb)
+
 # Developing Interactive Dashboards with Voilà and Solara
 
 ## Introduction

--- a/book/analytics/taxi.ipynb
+++ b/book/analytics/taxi.ipynb
@@ -5,6 +5,15 @@
    "id": "0",
    "metadata": {},
    "source": [
+    "[![image](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/giswqs/duckdb-spatial/blob/main/book/analytics/taxi.ipynb)\n",
+    "[![image](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/giswqs/duckdb-spatial/main?urlpath=lab/tree/book/analytics/taxi.ipynb)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1",
+   "metadata": {},
+   "source": [
     "# Analyzing NYC Taxi Data\n",
     "\n",
     "## Introduction\n",
@@ -19,7 +28,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "1",
+   "id": "2",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -28,7 +37,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "2",
+   "id": "3",
    "metadata": {},
    "source": [
     "## Library Import"
@@ -37,7 +46,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "3",
+   "id": "4",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -47,7 +56,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "4",
+   "id": "5",
    "metadata": {},
    "source": [
     "## Installing and Loading Extensions"
@@ -56,7 +65,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "5",
+   "id": "6",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -69,7 +78,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "6",
+   "id": "7",
    "metadata": {},
    "source": [
     "## Loading Taxi Data"
@@ -78,7 +87,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "7",
+   "id": "8",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -94,20 +103,10 @@
   },
   {
    "cell_type": "markdown",
-   "id": "8",
+   "id": "9",
    "metadata": {},
    "source": [
     "### Inspecting the Data"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "9",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "con.sql(\"DESCRIBE trips\")"
    ]
   },
   {
@@ -117,13 +116,23 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "con.sql(\"SELECT * FROM trips LIMIT 10\")"
+    "con.sql(\"DESCRIBE trips\")"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
    "id": "11",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "con.sql(\"SELECT * FROM trips LIMIT 10\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "12",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -140,7 +149,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "12",
+   "id": "13",
    "metadata": {},
    "source": [
     "## Temporal Analysis\n",
@@ -151,7 +160,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "13",
+   "id": "14",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -171,7 +180,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "14",
+   "id": "15",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -189,7 +198,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "15",
+   "id": "16",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -198,7 +207,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "16",
+   "id": "17",
    "metadata": {},
    "source": [
     "### Trips by Day of Week"
@@ -207,7 +216,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "17",
+   "id": "18",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -228,7 +237,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "18",
+   "id": "19",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -246,7 +255,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "19",
+   "id": "20",
    "metadata": {},
    "source": [
     "### Peak vs Off-Peak Analysis"
@@ -255,7 +264,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "20",
+   "id": "21",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -282,7 +291,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "21",
+   "id": "22",
    "metadata": {},
    "source": [
     "## Loading Taxi Zone Lookup Data"
@@ -291,7 +300,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "22",
+   "id": "23",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -306,7 +315,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "23",
+   "id": "24",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -319,7 +328,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "24",
+   "id": "25",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -333,7 +342,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "25",
+   "id": "26",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -349,7 +358,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "26",
+   "id": "27",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -358,7 +367,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "27",
+   "id": "28",
    "metadata": {},
    "source": [
     "## Spatial Analysis\n",
@@ -369,7 +378,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "28",
+   "id": "29",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -394,7 +403,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "29",
+   "id": "30",
    "metadata": {},
    "source": [
     "### Trip Distance Distribution"
@@ -403,7 +412,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "30",
+   "id": "31",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -430,7 +439,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "31",
+   "id": "32",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -444,7 +453,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "32",
+   "id": "33",
    "metadata": {},
    "source": [
     "### Geographic Distribution Using H3"
@@ -453,7 +462,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "33",
+   "id": "34",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -465,7 +474,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "34",
+   "id": "35",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -475,7 +484,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "35",
+   "id": "36",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -500,7 +509,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "36",
+   "id": "37",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -510,7 +519,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "37",
+   "id": "38",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -521,7 +530,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "38",
+   "id": "39",
    "metadata": {},
    "source": [
     "## Trip Flow Analysis\n",
@@ -532,7 +541,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "39",
+   "id": "40",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -564,7 +573,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "40",
+   "id": "41",
    "metadata": {},
    "source": [
     "### Airport Trips Analysis"
@@ -573,7 +582,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "41",
+   "id": "42",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -601,7 +610,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "42",
+   "id": "43",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -615,7 +624,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "43",
+   "id": "44",
    "metadata": {},
    "source": [
     "## Payment and Economic Analysis\n",
@@ -626,7 +635,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "44",
+   "id": "45",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -654,7 +663,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "45",
+   "id": "46",
    "metadata": {},
    "source": [
     "### Tipping Patterns"
@@ -663,7 +672,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "46",
+   "id": "47",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -690,7 +699,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "47",
+   "id": "48",
    "metadata": {},
    "source": [
     "### Fare per Mile Analysis"
@@ -699,7 +708,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "48",
+   "id": "49",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -724,7 +733,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "49",
+   "id": "50",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -740,7 +749,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "50",
+   "id": "51",
    "metadata": {},
    "source": [
     "## Passenger Behavior Analysis"
@@ -749,7 +758,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "51",
+   "id": "52",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -770,7 +779,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "52",
+   "id": "53",
    "metadata": {},
    "source": [
     "## Multi-Month Analysis"
@@ -779,7 +788,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "53",
+   "id": "54",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -806,7 +815,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "54",
+   "id": "55",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -827,7 +836,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "55",
+   "id": "56",
    "metadata": {},
    "source": [
     "## Visualization\n",
@@ -838,7 +847,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "56",
+   "id": "57",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -853,7 +862,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "57",
+   "id": "58",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -867,7 +876,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "58",
+   "id": "59",
    "metadata": {},
    "source": [
     "### Merging with Geographic Data"
@@ -876,7 +885,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "59",
+   "id": "60",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -894,7 +903,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "60",
+   "id": "61",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -904,7 +913,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "61",
+   "id": "62",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -913,7 +922,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "62",
+   "id": "63",
    "metadata": {},
    "source": [
     "### 2D Choropleth Maps"
@@ -922,7 +931,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "63",
+   "id": "64",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -934,7 +943,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "64",
+   "id": "65",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -945,7 +954,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "65",
+   "id": "66",
    "metadata": {},
    "source": [
     "### 3D Extruded Visualizations"
@@ -954,7 +963,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "66",
+   "id": "67",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -964,7 +973,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "67",
+   "id": "68",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -983,7 +992,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "68",
+   "id": "69",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1001,7 +1010,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "69",
+   "id": "70",
    "metadata": {},
    "source": [
     "## Performance Optimization Tips\n",
@@ -1012,7 +1021,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "70",
+   "id": "71",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1027,7 +1036,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "71",
+   "id": "72",
    "metadata": {},
    "source": [
     "### Sample for Exploration"
@@ -1036,7 +1045,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "72",
+   "id": "73",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1049,7 +1058,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "73",
+   "id": "74",
    "metadata": {},
    "source": [
     "## Key Takeaways\n",
@@ -1062,14 +1071,14 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "74",
+   "id": "75",
    "metadata": {},
    "outputs": [],
    "source": []
   },
   {
    "cell_type": "markdown",
-   "id": "75",
+   "id": "76",
    "metadata": {},
    "source": [
     "### Exercise 2: Weekend vs. Weekday Patterns"
@@ -1078,14 +1087,14 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "76",
+   "id": "77",
    "metadata": {},
    "outputs": [],
    "source": []
   },
   {
    "cell_type": "markdown",
-   "id": "77",
+   "id": "78",
    "metadata": {},
    "source": [
     "### Exercise 3: Airport Connection Analysis"
@@ -1094,14 +1103,14 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "78",
+   "id": "79",
    "metadata": {},
    "outputs": [],
    "source": []
   },
   {
    "cell_type": "markdown",
-   "id": "79",
+   "id": "80",
    "metadata": {},
    "source": [
     "### Exercise 4: Tipping Behavior Study"
@@ -1110,14 +1119,14 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "80",
+   "id": "81",
    "metadata": {},
    "outputs": [],
    "source": []
   },
   {
    "cell_type": "markdown",
-   "id": "81",
+   "id": "82",
    "metadata": {},
    "source": [
     "### Exercise 5: Speed and Congestion Analysis"
@@ -1126,14 +1135,14 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "82",
+   "id": "83",
    "metadata": {},
    "outputs": [],
    "source": []
   },
   {
    "cell_type": "markdown",
-   "id": "83",
+   "id": "84",
    "metadata": {},
    "source": [
     "### Exercise 6: Neighborhood Connectivity"
@@ -1142,14 +1151,14 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "84",
+   "id": "85",
    "metadata": {},
    "outputs": [],
    "source": []
   },
   {
    "cell_type": "markdown",
-   "id": "85",
+   "id": "86",
    "metadata": {},
    "source": [
     "### Exercise 7: Economic Revenue Analysis"
@@ -1158,14 +1167,14 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "86",
+   "id": "87",
    "metadata": {},
    "outputs": [],
    "source": []
   },
   {
    "cell_type": "markdown",
-   "id": "87",
+   "id": "88",
    "metadata": {},
    "source": [
     "### Exercise 8: Multi-Month Trend Analysis"
@@ -1174,7 +1183,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "88",
+   "id": "89",
    "metadata": {},
    "outputs": [],
    "source": []

--- a/book/analytics/taxi.md
+++ b/book/analytics/taxi.md
@@ -10,6 +10,10 @@ kernelspec:
   language: python
   name: python3
 ---
+
+[![image](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/giswqs/duckdb-spatial/blob/main/book/analytics/taxi.ipynb)
+[![image](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/giswqs/duckdb-spatial/main?urlpath=lab/tree/book/analytics/taxi.ipynb)
+
 # Analyzing NYC Taxi Data
 
 ## Introduction

--- a/book/analytics/wetlands.ipynb
+++ b/book/analytics/wetlands.ipynb
@@ -5,6 +5,15 @@
    "id": "0",
    "metadata": {},
    "source": [
+    "[![image](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/giswqs/duckdb-spatial/blob/main/book/analytics/wetlands.ipynb)\n",
+    "[![image](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/giswqs/duckdb-spatial/main?urlpath=lab/tree/book/analytics/wetlands.ipynb)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1",
+   "metadata": {},
+   "source": [
     "# Analyzing US National Wetlands Inventory\n",
     "\n",
     "## Introduction\n",
@@ -35,7 +44,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "1",
+   "id": "2",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -45,7 +54,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "2",
+   "id": "3",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -61,7 +70,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "3",
+   "id": "4",
    "metadata": {},
    "source": [
     "### Querying a Single State's Wetlands"
@@ -70,7 +79,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "4",
+   "id": "5",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -87,20 +96,10 @@
   },
   {
    "cell_type": "markdown",
-   "id": "5",
+   "id": "6",
    "metadata": {},
    "source": [
     "### Inspecting the Data Schema"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "6",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "con.sql(f\"DESCRIBE SELECT * FROM '{url}'\")"
    ]
   },
   {
@@ -110,12 +109,22 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "con.sql(f\"DESCRIBE SELECT * FROM '{url}'\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "con.sql(f\"SELECT DISTINCT WETLAND_TYPE FROM '{url}'\")"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "8",
+   "id": "9",
    "metadata": {},
    "source": [
     "### Alternative Access Methods\n",
@@ -136,7 +145,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "9",
+   "id": "10",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -146,7 +155,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "10",
+   "id": "11",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -169,7 +178,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "11",
+   "id": "12",
    "metadata": {},
    "source": [
     "### Creating Thematic Visualizations by Wetland Type"
@@ -178,7 +187,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "12",
+   "id": "13",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -235,7 +244,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "13",
+   "id": "14",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -249,7 +258,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "14",
+   "id": "15",
    "metadata": {},
    "source": [
     "## National-Scale Wetland Analysis\n",
@@ -260,7 +269,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "15",
+   "id": "16",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -272,7 +281,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "16",
+   "id": "17",
    "metadata": {},
    "source": [
     "### Analyzing Wetlands by State"
@@ -281,7 +290,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "17",
+   "id": "18",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -297,7 +306,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "18",
+   "id": "19",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -307,7 +316,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "19",
+   "id": "20",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -322,7 +331,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "20",
+   "id": "21",
    "metadata": {},
    "source": [
     "### Creating Tables for Spatial Joins"
@@ -331,7 +340,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "21",
+   "id": "22",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -341,7 +350,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "22",
+   "id": "23",
    "metadata": {},
    "source": [
     "### Loading State Boundaries for Mapping"
@@ -350,7 +359,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "23",
+   "id": "24",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -364,7 +373,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "24",
+   "id": "25",
    "metadata": {},
    "source": [
     "### Joining Wetland Statistics with State Geometries"
@@ -373,7 +382,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "25",
+   "id": "26",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -384,7 +393,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "26",
+   "id": "27",
    "metadata": {},
    "source": [
     "### Preparing Data for Visualization"
@@ -393,7 +402,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "27",
+   "id": "28",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -407,7 +416,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "28",
+   "id": "29",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -416,7 +425,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "29",
+   "id": "30",
    "metadata": {},
    "source": [
     "### Creating a Choropleth Map"
@@ -425,7 +434,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "30",
+   "id": "31",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -443,7 +452,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "31",
+   "id": "32",
    "metadata": {},
    "source": [
     "### Statistical Visualizations"
@@ -452,7 +461,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "32",
+   "id": "33",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -464,7 +473,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "33",
+   "id": "34",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -473,7 +482,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "34",
+   "id": "35",
    "metadata": {},
    "source": [
     "### Analyzing Wetland Area"
@@ -482,7 +491,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "35",
+   "id": "36",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -495,7 +504,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "36",
+   "id": "37",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -511,7 +520,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "37",
+   "id": "38",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -523,7 +532,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "38",
+   "id": "39",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -532,7 +541,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "39",
+   "id": "40",
    "metadata": {},
    "source": [
     "### Classification by Wetland Type"
@@ -541,7 +550,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "40",
+   "id": "41",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -559,7 +568,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "41",
+   "id": "42",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -578,7 +587,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "42",
+   "id": "43",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -589,7 +598,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "43",
+   "id": "44",
    "metadata": {},
    "source": [
     "## Key Takeaways\n",
@@ -602,14 +611,14 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "44",
+   "id": "45",
    "metadata": {},
    "outputs": [],
    "source": []
   },
   {
    "cell_type": "markdown",
-   "id": "45",
+   "id": "46",
    "metadata": {},
    "source": [
     "### Exercise 2: Regional Wetland Comparisons"
@@ -618,14 +627,14 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "46",
+   "id": "47",
    "metadata": {},
    "outputs": [],
    "source": []
   },
   {
    "cell_type": "markdown",
-   "id": "47",
+   "id": "48",
    "metadata": {},
    "source": [
     "### Exercise 3: National Wetland Type Classification"
@@ -634,14 +643,14 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "48",
+   "id": "49",
    "metadata": {},
    "outputs": [],
    "source": []
   },
   {
    "cell_type": "markdown",
-   "id": "49",
+   "id": "50",
    "metadata": {},
    "source": [
     "### Exercise 4: Focused Regional Analysis"
@@ -650,7 +659,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "50",
+   "id": "51",
    "metadata": {},
    "outputs": [],
    "source": []

--- a/book/analytics/wetlands.md
+++ b/book/analytics/wetlands.md
@@ -10,6 +10,10 @@ kernelspec:
   language: python
   name: python3
 ---
+
+[![image](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/giswqs/duckdb-spatial/blob/main/book/analytics/wetlands.ipynb)
+[![image](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/giswqs/duckdb-spatial/main?urlpath=lab/tree/book/analytics/wetlands.ipynb)
+
 # Analyzing US National Wetlands Inventory
 
 ## Introduction

--- a/book/foundations/introduction.ipynb
+++ b/book/foundations/introduction.ipynb
@@ -5,6 +5,15 @@
    "id": "0",
    "metadata": {},
    "source": [
+    "[![image](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/giswqs/duckdb-spatial/blob/main/book/foundations/introduction.ipynb)\n",
+    "[![image](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/giswqs/duckdb-spatial/main?urlpath=lab/tree/book/foundations/introduction.ipynb)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1",
+   "metadata": {},
+   "source": [
     "# Getting Started with DuckDB\n",
     "\n",
     "## Introduction\n",

--- a/book/foundations/introduction.md
+++ b/book/foundations/introduction.md
@@ -10,6 +10,10 @@ kernelspec:
   language: python
   name: python3
 ---
+
+[![image](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/giswqs/duckdb-spatial/blob/main/book/foundations/introduction.ipynb)
+[![image](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/giswqs/duckdb-spatial/main?urlpath=lab/tree/book/foundations/introduction.ipynb)
+
 # Getting Started with DuckDB
 
 ## Introduction

--- a/book/foundations/python-api.ipynb
+++ b/book/foundations/python-api.ipynb
@@ -5,6 +5,15 @@
    "id": "0",
    "metadata": {},
    "source": [
+    "[![image](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/giswqs/duckdb-spatial/blob/main/book/foundations/python-api.ipynb)\n",
+    "[![image](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/giswqs/duckdb-spatial/main?urlpath=lab/tree/book/foundations/python-api.ipynb)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1",
+   "metadata": {},
+   "source": [
     "# DuckDB Python Integration\n",
     "\n",
     "## Introduction\n",
@@ -19,7 +28,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "1",
+   "id": "2",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -28,7 +37,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "2",
+   "id": "3",
    "metadata": {},
    "source": [
     "### Library Import and Initial Setup"
@@ -37,7 +46,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "3",
+   "id": "4",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -48,7 +57,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "4",
+   "id": "5",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -58,7 +67,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "5",
+   "id": "6",
    "metadata": {},
    "source": [
     "## Installing and Loading Extensions"
@@ -67,7 +76,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "6",
+   "id": "7",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -79,7 +88,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "7",
+   "id": "8",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -89,7 +98,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "8",
+   "id": "9",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -103,7 +112,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "9",
+   "id": "10",
    "metadata": {},
    "source": [
     "## Reading Data from Multiple Sources\n",
@@ -114,7 +123,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "10",
+   "id": "11",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -123,20 +132,10 @@
   },
   {
    "cell_type": "markdown",
-   "id": "11",
+   "id": "12",
    "metadata": {},
    "source": [
     "### Reading CSV Files from URLs"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "12",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "con.read_csv(\"https://data.gishub.org/duckdb/cities.csv\")"
    ]
   },
   {
@@ -146,12 +145,22 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "con.read_csv(\"https://data.gishub.org/duckdb/cities.csv\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "14",
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "con.read_csv(\"https://data.gishub.org/duckdb/countries.csv\")"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "14",
+   "id": "15",
    "metadata": {},
    "source": [
     "### Understanding DuckDB Relations"
@@ -160,7 +169,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "15",
+   "id": "16",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -171,7 +180,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "16",
+   "id": "17",
    "metadata": {},
    "source": [
     "## Seamless Integration with Pandas DataFrames\n",
@@ -182,7 +191,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "17",
+   "id": "18",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -193,7 +202,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "18",
+   "id": "19",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -205,7 +214,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "19",
+   "id": "20",
    "metadata": {},
    "source": [
     "### The Bidirectional Workflow"
@@ -214,7 +223,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "20",
+   "id": "21",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -232,7 +241,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "21",
+   "id": "22",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -263,7 +272,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "22",
+   "id": "23",
    "metadata": {},
    "source": [
     "### Performance Considerations\n",
@@ -274,7 +283,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "23",
+   "id": "24",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -291,7 +300,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "24",
+   "id": "25",
    "metadata": {},
    "source": [
     "## Result Conversion and Output Formats\n",
@@ -302,7 +311,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "25",
+   "id": "26",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -312,7 +321,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "26",
+   "id": "27",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -323,7 +332,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "27",
+   "id": "28",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -334,7 +343,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "28",
+   "id": "29",
    "metadata": {},
    "source": [
     "### Converting to Pandas DataFrames"
@@ -343,7 +352,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "29",
+   "id": "30",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -352,7 +361,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "30",
+   "id": "31",
    "metadata": {},
    "source": [
     "### Converting to NumPy Arrays"
@@ -361,7 +370,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "31",
+   "id": "32",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -373,7 +382,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "32",
+   "id": "33",
    "metadata": {},
    "source": [
     "### Converting to Apache Arrow Tables"
@@ -382,7 +391,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "33",
+   "id": "34",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -392,7 +401,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "34",
+   "id": "35",
    "metadata": {},
    "source": [
     "### Choosing the Right Format\n",
@@ -403,7 +412,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "35",
+   "id": "36",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -414,7 +423,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "36",
+   "id": "37",
    "metadata": {},
    "source": [
     "## Persistent Storage and Database Files\n",
@@ -425,7 +434,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "37",
+   "id": "38",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -444,7 +453,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "38",
+   "id": "39",
    "metadata": {},
    "source": [
     "### Connecting to Existing Databases"
@@ -453,7 +462,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "39",
+   "id": "40",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -469,7 +478,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "40",
+   "id": "41",
    "metadata": {},
    "source": [
     "### Connection Management and Cleanup"
@@ -478,7 +487,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "41",
+   "id": "42",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -495,7 +504,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "42",
+   "id": "43",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -512,7 +521,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "43",
+   "id": "44",
    "metadata": {},
    "source": [
     "### Use Cases for Persistent vs In-Memory Databases\n",
@@ -523,7 +532,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "44",
+   "id": "45",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -535,7 +544,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "45",
+   "id": "46",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -548,7 +557,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "46",
+   "id": "47",
    "metadata": {},
    "source": [
     "## Key Takeaways\n",
@@ -561,14 +570,14 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "47",
+   "id": "48",
    "metadata": {},
    "outputs": [],
    "source": []
   },
   {
    "cell_type": "markdown",
-   "id": "48",
+   "id": "49",
    "metadata": {},
    "source": [
     "### Exercise 2: Loading Remote Data"
@@ -577,14 +586,14 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "49",
+   "id": "50",
    "metadata": {},
    "outputs": [],
    "source": []
   },
   {
    "cell_type": "markdown",
-   "id": "50",
+   "id": "51",
    "metadata": {},
    "source": [
     "### Exercise 3: SQL to DataFrame Conversion"
@@ -593,14 +602,14 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "51",
+   "id": "52",
    "metadata": {},
    "outputs": [],
    "source": []
   },
   {
    "cell_type": "markdown",
-   "id": "52",
+   "id": "53",
    "metadata": {},
    "source": [
     "### Exercise 4: Querying DataFrames with SQL"
@@ -609,14 +618,14 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "53",
+   "id": "54",
    "metadata": {},
    "outputs": [],
    "source": []
   },
   {
    "cell_type": "markdown",
-   "id": "54",
+   "id": "55",
    "metadata": {},
    "source": [
     "### Exercise 5: Bidirectional Workflows"
@@ -625,14 +634,14 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "55",
+   "id": "56",
    "metadata": {},
    "outputs": [],
    "source": []
   },
   {
    "cell_type": "markdown",
-   "id": "56",
+   "id": "57",
    "metadata": {},
    "source": [
     "### Exercise 6: Result Format Conversion"
@@ -641,14 +650,14 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "57",
+   "id": "58",
    "metadata": {},
    "outputs": [],
    "source": []
   },
   {
    "cell_type": "markdown",
-   "id": "58",
+   "id": "59",
    "metadata": {},
    "source": [
     "### Exercise 7: Persistent Storage"
@@ -657,14 +666,14 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "59",
+   "id": "60",
    "metadata": {},
    "outputs": [],
    "source": []
   },
   {
    "cell_type": "markdown",
-   "id": "60",
+   "id": "61",
    "metadata": {},
    "source": [
     "### Exercise 8: Joining SQL and Python Logic"
@@ -673,14 +682,14 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "61",
+   "id": "62",
    "metadata": {},
    "outputs": [],
    "source": []
   },
   {
    "cell_type": "markdown",
-   "id": "62",
+   "id": "63",
    "metadata": {},
    "source": [
     "### Exercise 9: Writing Results to Files"
@@ -689,14 +698,14 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "63",
+   "id": "64",
    "metadata": {},
    "outputs": [],
    "source": []
   },
   {
    "cell_type": "markdown",
-   "id": "64",
+   "id": "65",
    "metadata": {},
    "source": [
     "### Exercise 10: Practical Integration Challenge"
@@ -705,7 +714,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "65",
+   "id": "66",
    "metadata": {},
    "outputs": [],
    "source": []

--- a/book/foundations/python-api.md
+++ b/book/foundations/python-api.md
@@ -10,6 +10,10 @@ kernelspec:
   language: python
   name: python3
 ---
+
+[![image](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/giswqs/duckdb-spatial/blob/main/book/foundations/python-api.ipynb)
+[![image](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/giswqs/duckdb-spatial/main?urlpath=lab/tree/book/foundations/python-api.ipynb)
+
 # DuckDB Python Integration
 
 ## Introduction

--- a/book/foundations/sql-basics.ipynb
+++ b/book/foundations/sql-basics.ipynb
@@ -5,6 +5,15 @@
    "id": "0",
    "metadata": {},
    "source": [
+    "[![image](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/giswqs/duckdb-spatial/blob/main/book/foundations/sql-basics.ipynb)\n",
+    "[![image](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/giswqs/duckdb-spatial/main?urlpath=lab/tree/book/foundations/sql-basics.ipynb)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1",
+   "metadata": {},
+   "source": [
     "# Essential SQL for Spatial Analysis\n",
     "\n",
     "## Introduction\n",
@@ -37,7 +46,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "1",
+   "id": "2",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -46,20 +55,10 @@
   },
   {
    "cell_type": "markdown",
-   "id": "2",
+   "id": "3",
    "metadata": {},
    "source": [
     "## Install Extensions"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "3",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "SELECT * FROM duckdb_extensions();"
    ]
   },
   {
@@ -69,26 +68,26 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "SELECT * FROM duckdb_extensions();"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "INSTALL httpfs;\n",
     "LOAD httpfs;"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "5",
+   "id": "6",
    "metadata": {},
    "source": [
     "## Reading CSV Files from URLs"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "6",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "SELECT * FROM 'https://data.gishub.org/duckdb/cities.csv';"
    ]
   },
   {
@@ -98,25 +97,25 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "SELECT * FROM 'https://data.gishub.org/duckdb/countries.csv';"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "8",
-   "metadata": {},
-   "source": [
-    "## Creating Tables for Better Performance"
+    "SELECT * FROM 'https://data.gishub.org/duckdb/cities.csv';"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "9",
+   "id": "8",
    "metadata": {},
    "outputs": [],
    "source": [
-    "CREATE TABLE cities AS SELECT * FROM 'https://data.gishub.org/duckdb/cities.csv';"
+    "SELECT * FROM 'https://data.gishub.org/duckdb/countries.csv';"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9",
+   "metadata": {},
+   "source": [
+    "## Creating Tables for Better Performance"
    ]
   },
   {
@@ -126,7 +125,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "CREATE TABLE countries AS SELECT * FROM 'https://data.gishub.org/duckdb/countries.csv';"
+    "CREATE TABLE cities AS SELECT * FROM 'https://data.gishub.org/duckdb/cities.csv';"
    ]
   },
   {
@@ -136,7 +135,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "FROM cities;"
+    "CREATE TABLE countries AS SELECT * FROM 'https://data.gishub.org/duckdb/countries.csv';"
    ]
   },
   {
@@ -146,12 +145,22 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "FROM cities;"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "13",
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "FROM countries;"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "13",
+   "id": "14",
    "metadata": {},
    "source": [
     "## The SQL SELECT Statement"
@@ -160,7 +169,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "14",
+   "id": "15",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -169,7 +178,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "15",
+   "id": "16",
    "metadata": {},
    "source": [
     "### Limiting Results with LIMIT"
@@ -178,7 +187,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "16",
+   "id": "17",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -187,7 +196,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "17",
+   "id": "18",
    "metadata": {},
    "source": [
     "### Selecting Specific Columns"
@@ -196,7 +205,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "18",
+   "id": "19",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -205,7 +214,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "19",
+   "id": "20",
    "metadata": {},
    "source": [
     "### Finding Unique Values with DISTINCT"
@@ -214,7 +223,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "20",
+   "id": "21",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -223,7 +232,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "21",
+   "id": "22",
    "metadata": {},
    "source": [
     "### Basic Aggregate Functions\n",
@@ -234,7 +243,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "22",
+   "id": "23",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -243,7 +252,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "23",
+   "id": "24",
    "metadata": {},
    "source": [
     "#### Counting Unique Categories"
@@ -252,7 +261,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "24",
+   "id": "25",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -261,20 +270,10 @@
   },
   {
    "cell_type": "markdown",
-   "id": "25",
+   "id": "26",
    "metadata": {},
    "source": [
     "#### Finding Extremes"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "26",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "SELECT MAX(population) FROM cities;"
    ]
   },
   {
@@ -284,12 +283,22 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "SELECT MAX(population) FROM cities;"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "28",
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "SELECT MIN(population) FROM cities;"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "28",
+   "id": "29",
    "metadata": {},
    "source": [
     "#### Calculating Totals"
@@ -298,7 +307,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "29",
+   "id": "30",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -307,7 +316,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "30",
+   "id": "31",
    "metadata": {},
    "source": [
     "#### Computing Averages"
@@ -316,7 +325,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "31",
+   "id": "32",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -325,7 +334,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "32",
+   "id": "33",
    "metadata": {},
    "source": [
     "### Sorting Results with ORDER BY\n",
@@ -336,7 +345,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "33",
+   "id": "34",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -345,7 +354,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "34",
+   "id": "35",
    "metadata": {},
    "source": [
     "#### Multi-Level Sorting"
@@ -354,7 +363,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "35",
+   "id": "36",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -364,7 +373,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "36",
+   "id": "37",
    "metadata": {},
    "source": [
     "#### Spatial Sorting Applications"
@@ -373,7 +382,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "37",
+   "id": "38",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -384,7 +393,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "38",
+   "id": "39",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -394,7 +403,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "39",
+   "id": "40",
    "metadata": {},
    "source": [
     "### Calculated Columns and Expressions\n",
@@ -405,7 +414,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "40",
+   "id": "41",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -419,7 +428,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "41",
+   "id": "42",
    "metadata": {},
    "source": [
     "#### Geographic Calculations"
@@ -428,7 +437,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "42",
+   "id": "43",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -444,20 +453,10 @@
   },
   {
    "cell_type": "markdown",
-   "id": "43",
+   "id": "44",
    "metadata": {},
    "source": [
     "## Filtering Data with the WHERE Clause"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "44",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "SELECT * FROM cities WHERE country='USA';"
    ]
   },
   {
@@ -467,7 +466,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "SELECT * FROM cities WHERE country='USA' OR country='CAN';"
+    "SELECT * FROM cities WHERE country='USA';"
    ]
   },
   {
@@ -477,25 +476,25 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "SELECT * FROM cities WHERE country='USA' AND population>1000000;"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "47",
-   "metadata": {},
-   "source": [
-    "## Pattern Matching with LIKE"
+    "SELECT * FROM cities WHERE country='USA' OR country='CAN';"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "48",
+   "id": "47",
    "metadata": {},
    "outputs": [],
    "source": [
-    "SELECT * FROM cities WHERE country LIKE 'U%';"
+    "SELECT * FROM cities WHERE country='USA' AND population>1000000;"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "48",
+   "metadata": {},
+   "source": [
+    "## Pattern Matching with LIKE"
    ]
   },
   {
@@ -505,7 +504,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "SELECT * FROM cities WHERE country LIKE '%A';"
+    "SELECT * FROM cities WHERE country LIKE 'U%';"
    ]
   },
   {
@@ -515,12 +514,22 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "SELECT * FROM cities WHERE country LIKE '%A';"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "51",
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "SELECT * FROM cities WHERE country LIKE '_S_';"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "51",
+   "id": "52",
    "metadata": {},
    "source": [
     "## The IN Operator"
@@ -529,7 +538,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "52",
+   "id": "53",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -538,7 +547,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "53",
+   "id": "54",
    "metadata": {},
    "source": [
     "## The BETWEEN Operator"
@@ -547,7 +556,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "54",
+   "id": "55",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -556,20 +565,10 @@
   },
   {
    "cell_type": "markdown",
-   "id": "55",
+   "id": "56",
    "metadata": {},
    "source": [
     "## Combining Data with SQL Joins"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "56",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "SELECT COUNT(*) FROM cities;"
    ]
   },
   {
@@ -579,7 +578,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "SELECT * FROM cities LIMIT 10;"
+    "SELECT COUNT(*) FROM cities;"
    ]
   },
   {
@@ -589,7 +588,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "SELECT COUNT(*) FROM countries;"
+    "SELECT * FROM cities LIMIT 10;"
    ]
   },
   {
@@ -599,25 +598,25 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "SELECT * FROM countries LIMIT 10;"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "60",
-   "metadata": {},
-   "source": [
-    "### SQL Inner Join"
+    "SELECT COUNT(*) FROM countries;"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "61",
+   "id": "60",
    "metadata": {},
    "outputs": [],
    "source": [
-    "SELECT * FROM cities INNER JOIN countries ON cities.country = countries.\"Alpha3_code\";"
+    "SELECT * FROM countries LIMIT 10;"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "61",
+   "metadata": {},
+   "source": [
+    "### SQL Inner Join"
    ]
   },
   {
@@ -627,12 +626,22 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "SELECT * FROM cities INNER JOIN countries ON cities.country = countries.\"Alpha3_code\";"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "63",
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "SELECT name, cities.\"country\", countries.\"Country\" FROM cities INNER JOIN countries ON cities.country = countries.\"Alpha3_code\";"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "63",
+   "id": "64",
    "metadata": {},
    "source": [
     "### SQL Left Join"
@@ -641,7 +650,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "64",
+   "id": "65",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -650,7 +659,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "65",
+   "id": "66",
    "metadata": {},
    "source": [
     "### SQL Right Join"
@@ -659,7 +668,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "66",
+   "id": "67",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -668,7 +677,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "67",
+   "id": "68",
    "metadata": {},
    "source": [
     "### SQL Full Join"
@@ -677,7 +686,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "68",
+   "id": "69",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -686,7 +695,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "69",
+   "id": "70",
    "metadata": {},
    "source": [
     "### SQL Union"
@@ -695,7 +704,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "70",
+   "id": "71",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -706,20 +715,10 @@
   },
   {
    "cell_type": "markdown",
-   "id": "71",
+   "id": "72",
    "metadata": {},
    "source": [
     "## Query Plans and Performance"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "72",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "EXPLAIN SELECT country, COUNT(*) FROM cities GROUP BY country;"
    ]
   },
   {
@@ -729,12 +728,22 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "EXPLAIN SELECT country, COUNT(*) FROM cities GROUP BY country;"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "74",
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "EXPLAIN ANALYZE SELECT country, COUNT(*) FROM cities GROUP BY country;"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "74",
+   "id": "75",
    "metadata": {},
    "source": [
     "## Aggregating Data for Summary Statistics\n",
@@ -745,7 +754,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "75",
+   "id": "76",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -758,7 +767,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "76",
+   "id": "77",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -771,24 +780,10 @@
   },
   {
    "cell_type": "markdown",
-   "id": "77",
+   "id": "78",
    "metadata": {},
    "source": [
     "### Filtering Aggregated Results with HAVING"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "78",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "SELECT COUNT(name), country\n",
-    "FROM cities\n",
-    "GROUP BY country\n",
-    "HAVING COUNT(name) > 40\n",
-    "ORDER BY COUNT(name) DESC;"
    ]
   },
   {
@@ -798,6 +793,20 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "SELECT COUNT(name), country\n",
+    "FROM cities\n",
+    "GROUP BY country\n",
+    "HAVING COUNT(name) > 40\n",
+    "ORDER BY COUNT(name) DESC;"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "80",
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "SELECT countries.\"Country\", COUNT(name)\n",
     "FROM cities\n",
     "LEFT JOIN countries ON cities.country = countries.\"Alpha3_code\"\n",
@@ -808,7 +817,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "80",
+   "id": "81",
    "metadata": {},
    "source": [
     "## Conditional Statements"
@@ -817,7 +826,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "81",
+   "id": "82",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -832,20 +841,10 @@
   },
   {
    "cell_type": "markdown",
-   "id": "82",
+   "id": "83",
    "metadata": {},
    "source": [
     "## Saving Results"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "83",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "CREATE TABLE cities2 AS SELECT * FROM cities;"
    ]
   },
   {
@@ -855,13 +854,23 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "FROM cities2;"
+    "CREATE TABLE cities2 AS SELECT * FROM cities;"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
    "id": "85",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "FROM cities2;"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "86",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -872,7 +881,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "86",
+   "id": "87",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -882,7 +891,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "87",
+   "id": "88",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -891,7 +900,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "88",
+   "id": "89",
    "metadata": {},
    "source": [
     "## Advanced SQL Features for Spatial Analysis\n",
@@ -904,7 +913,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "89",
+   "id": "90",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -918,7 +927,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "90",
+   "id": "91",
    "metadata": {},
    "source": [
     "#### Moving Averages and Spatial Trends"
@@ -927,7 +936,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "91",
+   "id": "92",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -944,7 +953,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "92",
+   "id": "93",
    "metadata": {},
    "source": [
     "### Common Table Expressions (CTEs)\n",
@@ -955,7 +964,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "93",
+   "id": "94",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -989,7 +998,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "94",
+   "id": "95",
    "metadata": {},
    "source": [
     "### Subqueries for Spatial Comparisons\n",
@@ -1000,7 +1009,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "95",
+   "id": "96",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1019,7 +1028,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "96",
+   "id": "97",
    "metadata": {},
    "source": [
     "### String Functions for Spatial Data\n",
@@ -1030,7 +1039,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "97",
+   "id": "98",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1050,7 +1059,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "98",
+   "id": "99",
    "metadata": {},
    "source": [
     "### Date and Time Functions"
@@ -1059,7 +1068,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "99",
+   "id": "100",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1080,7 +1089,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "100",
+   "id": "101",
    "metadata": {},
    "source": [
     "## SQL Comments and Documentation\n",
@@ -1091,7 +1100,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "101",
+   "id": "102",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1102,7 +1111,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "102",
+   "id": "103",
    "metadata": {},
    "source": [
     "### Multi-Line Comments"
@@ -1111,7 +1120,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "103",
+   "id": "104",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1129,7 +1138,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "104",
+   "id": "105",
    "metadata": {},
    "source": [
     "## Key Takeaways\n",

--- a/book/foundations/sql-basics.md
+++ b/book/foundations/sql-basics.md
@@ -10,6 +10,10 @@ kernelspec:
   display_name: DuckDB
   language: ''
 ---
+
+[![image](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/giswqs/duckdb-spatial/blob/main/book/foundations/sql-basics.ipynb)
+[![image](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/giswqs/duckdb-spatial/main?urlpath=lab/tree/book/foundations/sql-basics.ipynb)
+
 # Essential SQL for Spatial Analysis
 
 ## Introduction

--- a/book/preface.ipynb
+++ b/book/preface.ipynb
@@ -5,6 +5,15 @@
    "id": "0",
    "metadata": {},
    "source": [
+    "[![image](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/giswqs/duckdb-spatial/blob/main/book/preface.ipynb)\n",
+    "[![image](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/giswqs/duckdb-spatial/main?urlpath=lab/tree/book/preface.ipynb)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1",
+   "metadata": {},
+   "source": [
     "# Preface\n",
     "\n",
     "## Introduction\n",
@@ -144,7 +153,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "1",
+   "id": "2",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -158,7 +167,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "2",
+   "id": "3",
    "metadata": {},
    "source": [
     "**SQL Style Guide**: For consistency and readability, SQL examples follow these patterns:\n",

--- a/book/preface.md
+++ b/book/preface.md
@@ -25,6 +25,9 @@ exports:
     template: lapreprint-typst
 ---
 
+[![image](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/giswqs/duckdb-spatial/blob/main/book/preface.ipynb)
+[![image](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/giswqs/duckdb-spatial/main?urlpath=lab/tree/book/preface.ipynb)
+
 # Preface
 
 ## Introduction

--- a/book/spatial/data-export.ipynb
+++ b/book/spatial/data-export.ipynb
@@ -5,6 +5,15 @@
    "id": "0",
    "metadata": {},
    "source": [
+    "[![image](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/giswqs/duckdb-spatial/blob/main/book/spatial/data-export.ipynb)\n",
+    "[![image](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/giswqs/duckdb-spatial/main?urlpath=lab/tree/book/spatial/data-export.ipynb)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1",
+   "metadata": {},
+   "source": [
     "# Exporting and Converting Spatial Data\n",
     "\n",
     "## Introduction\n",
@@ -19,7 +28,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "1",
+   "id": "2",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -28,7 +37,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "2",
+   "id": "3",
    "metadata": {},
    "source": [
     "### Library Import and Initial Setup"
@@ -37,7 +46,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "3",
+   "id": "4",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -48,7 +57,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "4",
+   "id": "5",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -58,7 +67,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "5",
+   "id": "6",
    "metadata": {},
    "source": [
     "## Installing and Loading Extensions"
@@ -67,7 +76,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "6",
+   "id": "7",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -77,7 +86,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "7",
+   "id": "8",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -88,7 +97,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "8",
+   "id": "9",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -99,7 +108,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "9",
+   "id": "10",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -110,7 +119,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "10",
+   "id": "11",
    "metadata": {},
    "source": [
     "## Loading Sample Data"
@@ -119,7 +128,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "11",
+   "id": "12",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -132,7 +141,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "12",
+   "id": "13",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -142,23 +151,13 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "13",
+   "id": "14",
    "metadata": {},
    "outputs": [],
    "source": [
     "con.sql(\n",
     "    \"SELECT COUNT(*) AS city_count, MIN(population) AS min_pop, MAX(population) AS max_pop, AVG(population) AS avg_pop FROM cities\"\n",
     ").show()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "14",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "con.sql(\"SUMMARIZE SELECT population FROM cities\").show()"
    ]
   },
   {
@@ -172,8 +171,18 @@
    ]
   },
   {
-   "cell_type": "markdown",
+   "cell_type": "code",
+   "execution_count": null,
    "id": "16",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "con.sql(\"SUMMARIZE SELECT population FROM cities\").show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "17",
    "metadata": {},
    "source": [
     "## Exporting to Pandas DataFrames\n",
@@ -184,7 +193,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "17",
+   "id": "18",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -195,7 +204,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "18",
+   "id": "19",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -204,7 +213,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "19",
+   "id": "20",
    "metadata": {},
    "source": [
     "### Exporting Filtered Query Results"
@@ -213,7 +222,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "20",
+   "id": "21",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -230,7 +239,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "21",
+   "id": "22",
    "metadata": {},
    "source": [
     "### Working with Geometry Columns in DataFrames"
@@ -239,7 +248,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "22",
+   "id": "23",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -255,7 +264,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "23",
+   "id": "24",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -265,7 +274,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "24",
+   "id": "25",
    "metadata": {},
    "source": [
     "### Converting Geometries to Text for DataFrames"
@@ -274,7 +283,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "25",
+   "id": "26",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -289,7 +298,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "26",
+   "id": "27",
    "metadata": {},
    "source": [
     "### Integrating with GeoPandas for Spatial Operations"
@@ -298,7 +307,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "27",
+   "id": "28",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -314,7 +323,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "28",
+   "id": "29",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -329,7 +338,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "29",
+   "id": "30",
    "metadata": {},
    "source": [
     "### Performance Considerations for DataFrame Export\n",
@@ -342,7 +351,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "30",
+   "id": "31",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -351,7 +360,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "31",
+   "id": "32",
    "metadata": {},
    "source": [
     "### Streaming Query Results to CSV"
@@ -360,7 +369,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "32",
+   "id": "33",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -374,7 +383,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "33",
+   "id": "34",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -394,7 +403,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "34",
+   "id": "35",
    "metadata": {},
    "source": [
     "### Handling Geometries in CSV Exports"
@@ -403,7 +412,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "35",
+   "id": "36",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -417,7 +426,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "36",
+   "id": "37",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -434,7 +443,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "37",
+   "id": "38",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -450,7 +459,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "38",
+   "id": "39",
    "metadata": {},
    "source": [
     "### When to Use CSV Export\n",
@@ -463,7 +472,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "39",
+   "id": "40",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -472,7 +481,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "40",
+   "id": "41",
    "metadata": {},
    "source": [
     "### Exporting Filtered Query Results to JSON"
@@ -481,7 +490,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "41",
+   "id": "42",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -490,7 +499,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "42",
+   "id": "43",
    "metadata": {},
    "source": [
     "### Handling Geometries in JSON Exports"
@@ -499,7 +508,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "43",
+   "id": "44",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -509,7 +518,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "44",
+   "id": "45",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -525,7 +534,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "45",
+   "id": "46",
    "metadata": {},
    "source": [
     "### When to Use JSON Export\n",
@@ -540,7 +549,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "46",
+   "id": "47",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -550,7 +559,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "47",
+   "id": "48",
    "metadata": {},
    "source": [
     "### Basic Excel Export Without Geometries"
@@ -559,7 +568,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "48",
+   "id": "49",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -570,7 +579,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "49",
+   "id": "50",
    "metadata": {},
    "source": [
     "### Including Spatial Information as Text Columns"
@@ -579,7 +588,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "50",
+   "id": "51",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -596,7 +605,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "51",
+   "id": "52",
    "metadata": {},
    "source": [
     "### Exporting Filtered and Aggregated Results to Excel"
@@ -605,7 +614,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "52",
+   "id": "53",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -626,7 +635,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "53",
+   "id": "54",
    "metadata": {},
    "source": [
     "### When to Use Excel Export\n",
@@ -641,7 +650,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "54",
+   "id": "55",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -650,7 +659,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "55",
+   "id": "56",
    "metadata": {},
    "source": [
     "### Exporting Filtered Query Results to Parquet"
@@ -659,7 +668,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "56",
+   "id": "57",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -668,7 +677,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "57",
+   "id": "58",
    "metadata": {},
    "source": [
     "### Partitioned Parquet Writes"
@@ -677,7 +686,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "58",
+   "id": "59",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -689,7 +698,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "59",
+   "id": "60",
    "metadata": {},
    "source": [
     "## Exporting to GeoJSON Format\n",
@@ -702,7 +711,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "60",
+   "id": "61",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -711,7 +720,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "61",
+   "id": "62",
    "metadata": {},
    "source": [
     "### Exporting Filtered Subsets to GeoJSON"
@@ -720,7 +729,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "62",
+   "id": "63",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -732,7 +741,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "63",
+   "id": "64",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -753,7 +762,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "64",
+   "id": "65",
    "metadata": {},
    "source": [
     "### Customizing GeoJSON Export Options"
@@ -762,7 +771,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "65",
+   "id": "66",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -775,7 +784,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "66",
+   "id": "67",
    "metadata": {},
    "source": [
     "### When to Use GeoJSON\n",
@@ -794,7 +803,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "67",
+   "id": "68",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -803,7 +812,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "68",
+   "id": "69",
    "metadata": {},
    "source": [
     "## Exporting to GeoPackage Format\n",
@@ -816,7 +825,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "69",
+   "id": "70",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -825,7 +834,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "70",
+   "id": "71",
    "metadata": {},
    "source": [
     "### Exporting Filtered Subsets to GeoPackage"
@@ -834,7 +843,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "71",
+   "id": "72",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -845,7 +854,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "72",
+   "id": "73",
    "metadata": {},
    "source": [
     "### When to Use GeoPackage Export\n",
@@ -860,14 +869,14 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "73",
+   "id": "74",
    "metadata": {},
    "outputs": [],
    "source": []
   },
   {
    "cell_type": "markdown",
-   "id": "74",
+   "id": "75",
    "metadata": {},
    "source": [
     "### Exercise 2: Filtered Exports to Multiple Formats"
@@ -876,14 +885,14 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "75",
+   "id": "76",
    "metadata": {},
    "outputs": [],
    "source": []
   },
   {
    "cell_type": "markdown",
-   "id": "76",
+   "id": "77",
    "metadata": {},
    "source": [
     "### Exercise 3: DataFrame Export and Manipulation"
@@ -892,14 +901,14 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "77",
+   "id": "78",
    "metadata": {},
    "outputs": [],
    "source": []
   },
   {
    "cell_type": "markdown",
-   "id": "78",
+   "id": "79",
    "metadata": {},
    "source": [
     "### Exercise 4: Exporting with Spatial Aggregations"
@@ -908,14 +917,14 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "79",
+   "id": "80",
    "metadata": {},
    "outputs": [],
    "source": []
   },
   {
    "cell_type": "markdown",
-   "id": "80",
+   "id": "81",
    "metadata": {},
    "source": [
     "### Exercise 5: GeoJSON Export for Web Mapping"
@@ -924,14 +933,14 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "81",
+   "id": "82",
    "metadata": {},
    "outputs": [],
    "source": []
   },
   {
    "cell_type": "markdown",
-   "id": "82",
+   "id": "83",
    "metadata": {},
    "source": [
     "### Exercise 6: GeoPackage Export for GIS Interoperability"
@@ -940,14 +949,14 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "83",
+   "id": "84",
    "metadata": {},
    "outputs": [],
    "source": []
   },
   {
    "cell_type": "markdown",
-   "id": "84",
+   "id": "85",
    "metadata": {},
    "source": [
     "### Exercise 7: Partitioned Parquet Export"
@@ -956,14 +965,14 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "85",
+   "id": "86",
    "metadata": {},
    "outputs": [],
    "source": []
   },
   {
    "cell_type": "markdown",
-   "id": "86",
+   "id": "87",
    "metadata": {},
    "source": [
     "### Exercise 8: Excel Export with Readable Geometries"
@@ -972,14 +981,14 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "87",
+   "id": "88",
    "metadata": {},
    "outputs": [],
    "source": []
   },
   {
    "cell_type": "markdown",
-   "id": "88",
+   "id": "89",
    "metadata": {},
    "source": [
     "### Exercise 9: Round-Trip Export and Import"
@@ -988,14 +997,14 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "89",
+   "id": "90",
    "metadata": {},
    "outputs": [],
    "source": []
   },
   {
    "cell_type": "markdown",
-   "id": "90",
+   "id": "91",
    "metadata": {},
    "source": [
     "### Exercise 10: Comprehensive Export Pipeline Challenge"
@@ -1004,7 +1013,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "91",
+   "id": "92",
    "metadata": {},
    "outputs": [],
    "source": []

--- a/book/spatial/data-export.md
+++ b/book/spatial/data-export.md
@@ -10,6 +10,10 @@ kernelspec:
   language: python
   name: python3
 ---
+
+[![image](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/giswqs/duckdb-spatial/blob/main/book/spatial/data-export.ipynb)
+[![image](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/giswqs/duckdb-spatial/main?urlpath=lab/tree/book/spatial/data-export.ipynb)
+
 # Exporting and Converting Spatial Data
 
 ## Introduction

--- a/book/spatial/data-import.ipynb
+++ b/book/spatial/data-import.ipynb
@@ -5,6 +5,15 @@
    "id": "0",
    "metadata": {},
    "source": [
+    "[![image](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/giswqs/duckdb-spatial/blob/main/book/spatial/data-import.ipynb)\n",
+    "[![image](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/giswqs/duckdb-spatial/main?urlpath=lab/tree/book/spatial/data-import.ipynb)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1",
+   "metadata": {},
+   "source": [
     "# Loading Spatial Data Formats\n",
     "\n",
     "## Introduction\n",
@@ -19,7 +28,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "1",
+   "id": "2",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -28,7 +37,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "2",
+   "id": "3",
    "metadata": {},
    "source": [
     "### Library Import and Initial Setup"
@@ -37,7 +46,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "3",
+   "id": "4",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -48,7 +57,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "4",
+   "id": "5",
    "metadata": {},
    "source": [
     "## Installing and Loading Extensions"
@@ -57,7 +66,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "5",
+   "id": "6",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -67,7 +76,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "6",
+   "id": "7",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -78,7 +87,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "7",
+   "id": "8",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -88,7 +97,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "8",
+   "id": "9",
    "metadata": {},
    "source": [
     "## Downloading Sample Data"
@@ -97,7 +106,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "9",
+   "id": "10",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -107,7 +116,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "10",
+   "id": "11",
    "metadata": {},
    "source": [
     "## Loading CSV Files with Coordinates\n",
@@ -118,7 +127,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "11",
+   "id": "12",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -127,7 +136,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "12",
+   "id": "13",
    "metadata": {},
    "source": [
     "### Overriding Automatic Detection"
@@ -136,7 +145,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "13",
+   "id": "14",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -145,7 +154,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "14",
+   "id": "15",
    "metadata": {},
    "source": [
     "### Parallel CSV Reading for Large Files"
@@ -154,7 +163,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "15",
+   "id": "16",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -163,20 +172,10 @@
   },
   {
    "cell_type": "markdown",
-   "id": "16",
+   "id": "17",
    "metadata": {},
    "source": [
     "### Querying CSV Files Directly in SQL"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "17",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "con.sql(\"SELECT * FROM 'cities.csv'\")"
    ]
   },
   {
@@ -186,25 +185,25 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "con.sql(\"SELECT * FROM read_csv_auto('cities.csv')\")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "19",
-   "metadata": {},
-   "source": [
-    "### Performance Considerations and Best Practices"
+    "con.sql(\"SELECT * FROM 'cities.csv'\")"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "20",
+   "id": "19",
    "metadata": {},
    "outputs": [],
    "source": [
-    "con.sql(\"COPY (SELECT * FROM 'cities.csv') TO 'cities-demo.parquet'\")"
+    "con.sql(\"SELECT * FROM read_csv_auto('cities.csv')\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "20",
+   "metadata": {},
+   "source": [
+    "### Performance Considerations and Best Practices"
    ]
   },
   {
@@ -214,7 +213,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "con.sql(\"DESCRIBE SELECT * FROM 'cities.csv'\").show()"
+    "con.sql(\"COPY (SELECT * FROM 'cities.csv') TO 'cities-demo.parquet'\")"
    ]
   },
   {
@@ -224,12 +223,22 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "con.sql(\"DESCRIBE SELECT * FROM 'cities.csv'\").show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "23",
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "con.sql(\"SELECT * FROM 'cities.csv' LIMIT 100\").show()"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "23",
+   "id": "24",
    "metadata": {},
    "source": [
     "## Loading JSON Files\n",
@@ -240,7 +249,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "24",
+   "id": "25",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -250,7 +259,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "25",
+   "id": "26",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -260,7 +269,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "26",
+   "id": "27",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -269,7 +278,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "27",
+   "id": "28",
    "metadata": {},
    "source": [
     "### Understanding JSON Format Variants\n",
@@ -282,7 +291,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "28",
+   "id": "29",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -295,7 +304,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "29",
+   "id": "30",
    "metadata": {},
    "source": [
     "## Querying Pandas DataFrames Directly\n",
@@ -306,7 +315,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "30",
+   "id": "31",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -317,7 +326,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "31",
+   "id": "32",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -326,7 +335,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "32",
+   "id": "33",
    "metadata": {},
    "source": [
     "### When to Use DataFrame Querying\n",
@@ -339,7 +348,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "33",
+   "id": "34",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -348,20 +357,10 @@
   },
   {
    "cell_type": "markdown",
-   "id": "34",
+   "id": "35",
    "metadata": {},
    "source": [
     "### Querying Parquet Files Directly in SQL"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "35",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "con.sql(\"SELECT * FROM 'cities.parquet'\")"
    ]
   },
   {
@@ -371,25 +370,25 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "con.sql(\"SELECT * FROM read_parquet('cities.parquet')\")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "37",
-   "metadata": {},
-   "source": [
-    "### Cloud Storage and Remote Parquet Files"
+    "con.sql(\"SELECT * FROM 'cities.parquet'\")"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "38",
+   "id": "37",
    "metadata": {},
    "outputs": [],
    "source": [
-    "con.sql(\"SELECT * FROM 'https://data.gishub.org/duckdb/cities.parquet'\")"
+    "con.sql(\"SELECT * FROM read_parquet('cities.parquet')\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "38",
+   "metadata": {},
+   "source": [
+    "### Cloud Storage and Remote Parquet Files"
    ]
   },
   {
@@ -399,13 +398,23 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "con.sql(\"SELECT * FROM 'https://data.gishub.org/duckdb/cities.parquet'\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "40",
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "url = \"s3://us-west-2.opendata.source.coop/vida/google-microsoft-osm-open-buildings/geoparquet/by_country/country_iso=USA/USA.parquet\"\n",
     "con.sql(f\"SELECT * FROM '{url}' LIMIT 10\")"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "40",
+   "id": "41",
    "metadata": {},
    "source": [
     "### When to Convert to Parquet"
@@ -414,7 +423,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "41",
+   "id": "42",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -423,7 +432,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "42",
+   "id": "43",
    "metadata": {},
    "source": [
     "## Loading GeoJSON Files with Spatial Geometries\n",
@@ -434,7 +443,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "43",
+   "id": "44",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -443,7 +452,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "44",
+   "id": "45",
    "metadata": {},
    "source": [
     "### Loading GeoJSON with ST_Read()"
@@ -452,7 +461,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "45",
+   "id": "46",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -461,7 +470,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "46",
+   "id": "47",
    "metadata": {},
    "source": [
     "### DuckDB's Shorthand SQL Syntax"
@@ -470,7 +479,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "47",
+   "id": "48",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -479,7 +488,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "48",
+   "id": "49",
    "metadata": {},
    "source": [
     "### Creating Persistent Spatial Tables"
@@ -488,7 +497,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "49",
+   "id": "50",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -497,20 +506,10 @@
   },
   {
    "cell_type": "markdown",
-   "id": "50",
+   "id": "51",
    "metadata": {},
    "source": [
     "### Querying the Spatial Table"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "51",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "con.table(\"cities\")"
    ]
   },
   {
@@ -520,12 +519,22 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "con.table(\"cities\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "53",
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "con.sql(\"SELECT * FROM cities\")"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "53",
+   "id": "54",
    "metadata": {},
    "source": [
     "### Understanding GDAL Dependencies\n",
@@ -540,7 +549,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "54",
+   "id": "55",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -550,7 +559,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "55",
+   "id": "56",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -559,7 +568,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "56",
+   "id": "57",
    "metadata": {},
    "source": [
     "### Creating Tables from Shapefiles"
@@ -568,7 +577,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "57",
+   "id": "58",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -581,7 +590,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "58",
+   "id": "59",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -591,7 +600,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "59",
+   "id": "60",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -600,7 +609,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "60",
+   "id": "61",
    "metadata": {},
    "source": [
     "### Shapefile Limitations and Modern Alternatives"
@@ -609,7 +618,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "61",
+   "id": "62",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -618,7 +627,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "62",
+   "id": "63",
    "metadata": {},
    "source": [
     "## Loading GeoParquet for Cloud-Native Spatial Analysis\n",
@@ -629,7 +638,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "63",
+   "id": "64",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -638,7 +647,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "64",
+   "id": "65",
    "metadata": {},
    "source": [
     "### Converting WKB Geometries to DuckDB's Spatial Type"
@@ -647,7 +656,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "65",
+   "id": "66",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -656,7 +665,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "66",
+   "id": "67",
    "metadata": {},
    "source": [
     "### Loading GeoParquet from Cloud Storage"
@@ -665,7 +674,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "67",
+   "id": "68",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -677,7 +686,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "68",
+   "id": "69",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -688,20 +697,10 @@
   },
   {
    "cell_type": "markdown",
-   "id": "69",
+   "id": "70",
    "metadata": {},
    "source": [
     "## Data Loading Performance Strategies"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "70",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "con.sql(\"FROM 'cities.parquet' USING SAMPLE 10%\")"
    ]
   },
   {
@@ -711,7 +710,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "con.sql(\"SELECT name, population FROM 'cities.parquet'\")"
+    "con.sql(\"FROM 'cities.parquet' USING SAMPLE 10%\")"
    ]
   },
   {
@@ -721,7 +720,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "con.sql(\"SELECT * FROM 'cities.parquet' WHERE population > 1000000\")"
+    "con.sql(\"SELECT name, population FROM 'cities.parquet'\")"
    ]
   },
   {
@@ -731,12 +730,22 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "con.sql(\"SELECT * FROM 'cities.parquet' WHERE population > 1000000\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "74",
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "con.sql(\"SELECT * FROM 'cities.parquet' LIMIT 100\")"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "74",
+   "id": "75",
    "metadata": {},
    "source": [
     "## Troubleshooting Common Data Loading Issues\n",
@@ -749,7 +758,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "75",
+   "id": "76",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -759,7 +768,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "76",
+   "id": "77",
    "metadata": {},
    "source": [
     "### Exercise 1: CSV Loading and Schema Inspection"
@@ -768,14 +777,14 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "77",
+   "id": "78",
    "metadata": {},
    "outputs": [],
    "source": []
   },
   {
    "cell_type": "markdown",
-   "id": "78",
+   "id": "79",
    "metadata": {},
    "source": [
     "### Exercise 2: Format Conversion for Performance"
@@ -784,14 +793,14 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "79",
+   "id": "80",
    "metadata": {},
    "outputs": [],
    "source": []
   },
   {
    "cell_type": "markdown",
-   "id": "80",
+   "id": "81",
    "metadata": {},
    "source": [
     "### Exercise 3: Loading GeoJSON with Spatial Geometries"
@@ -800,14 +809,14 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "81",
+   "id": "82",
    "metadata": {},
    "outputs": [],
    "source": []
   },
   {
    "cell_type": "markdown",
-   "id": "82",
+   "id": "83",
    "metadata": {},
    "source": [
     "### Exercise 4: Working with Shapefiles"
@@ -816,14 +825,14 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "83",
+   "id": "84",
    "metadata": {},
    "outputs": [],
    "source": []
   },
   {
    "cell_type": "markdown",
-   "id": "84",
+   "id": "85",
    "metadata": {},
    "source": [
     "### Exercise 5: Querying Pandas DataFrames with SQL"
@@ -832,14 +841,14 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "85",
+   "id": "86",
    "metadata": {},
    "outputs": [],
    "source": []
   },
   {
    "cell_type": "markdown",
-   "id": "86",
+   "id": "87",
    "metadata": {},
    "source": [
     "### Exercise 6: Cloud Data Access with GeoParquet"
@@ -848,14 +857,14 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "87",
+   "id": "88",
    "metadata": {},
    "outputs": [],
    "source": []
   },
   {
    "cell_type": "markdown",
-   "id": "88",
+   "id": "89",
    "metadata": {},
    "source": [
     "### Exercise 7: Format Comparison with Your Own Data"
@@ -864,7 +873,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "89",
+   "id": "90",
    "metadata": {},
    "outputs": [],
    "source": []

--- a/book/spatial/data-import.md
+++ b/book/spatial/data-import.md
@@ -10,6 +10,10 @@ kernelspec:
   language: python
   name: python3
 ---
+
+[![image](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/giswqs/duckdb-spatial/blob/main/book/spatial/data-import.ipynb)
+[![image](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/giswqs/duckdb-spatial/main?urlpath=lab/tree/book/spatial/data-import.ipynb)
+
 # Loading Spatial Data Formats
 
 ## Introduction

--- a/book/spatial/data-viz.ipynb
+++ b/book/spatial/data-viz.ipynb
@@ -5,6 +5,15 @@
    "id": "0",
    "metadata": {},
    "source": [
+    "[![image](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/giswqs/duckdb-spatial/blob/main/book/spatial/data-viz.ipynb)\n",
+    "[![image](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/giswqs/duckdb-spatial/main?urlpath=lab/tree/book/spatial/data-viz.ipynb)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1",
+   "metadata": {},
+   "source": [
     "# Interactive Data Visualization\n",
     "\n",
     "## Introduction\n",
@@ -19,7 +28,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "1",
+   "id": "2",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -29,7 +38,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "2",
+   "id": "3",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -39,7 +48,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "3",
+   "id": "4",
    "metadata": {},
    "source": [
     "## Downloading Sample Data"
@@ -48,7 +57,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "4",
+   "id": "5",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -58,7 +67,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "5",
+   "id": "6",
    "metadata": {},
    "source": [
     "## Connecting to DuckDB and Loading Extensions"
@@ -67,7 +76,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "6",
+   "id": "7",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -76,7 +85,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "7",
+   "id": "8",
    "metadata": {},
    "source": [
     "### Installing and Loading the Spatial Extension"
@@ -85,7 +94,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "8",
+   "id": "9",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -95,7 +104,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "9",
+   "id": "10",
    "metadata": {},
    "source": [
     "### Exploring the Database Contents"
@@ -104,7 +113,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "10",
+   "id": "11",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -113,7 +122,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "11",
+   "id": "12",
    "metadata": {},
    "source": [
     "## Visualizing Point Data\n",
@@ -124,7 +133,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "12",
+   "id": "13",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -136,7 +145,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "13",
+   "id": "14",
    "metadata": {},
    "source": [
     "### Transforming to GeoDataFrame with CRS Conversion"
@@ -145,7 +154,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "14",
+   "id": "15",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -157,7 +166,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "15",
+   "id": "16",
    "metadata": {},
    "source": [
     "### Creating a Basic Point Map"
@@ -166,7 +175,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "16",
+   "id": "17",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -177,7 +186,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "17",
+   "id": "18",
    "metadata": {},
    "source": [
     "### Customizing Point Symbology"
@@ -186,7 +195,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "18",
+   "id": "19",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -206,7 +215,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "19",
+   "id": "20",
    "metadata": {},
    "source": [
     "## Visualizing Line Data\n",
@@ -217,7 +226,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "20",
+   "id": "21",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -229,7 +238,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "21",
+   "id": "22",
    "metadata": {},
    "source": [
     "### Transforming Streets to GeoDataFrame"
@@ -238,7 +247,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "22",
+   "id": "23",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -248,7 +257,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "23",
+   "id": "24",
    "metadata": {},
    "source": [
     "### Creating a Basic Line Map"
@@ -257,7 +266,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "24",
+   "id": "25",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -268,7 +277,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "25",
+   "id": "26",
    "metadata": {},
    "source": [
     "### Customizing Line Symbology"
@@ -277,7 +286,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "26",
+   "id": "27",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -289,7 +298,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "27",
+   "id": "28",
    "metadata": {},
    "source": [
     "## Visualizing Polygon Data\n",
@@ -300,7 +309,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "28",
+   "id": "29",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -312,7 +321,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "29",
+   "id": "30",
    "metadata": {},
    "source": [
     "### Transforming Census Blocks to GeoDataFrame"
@@ -321,7 +330,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "30",
+   "id": "31",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -333,7 +342,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "31",
+   "id": "32",
    "metadata": {},
    "source": [
     "### Creating a Basic Polygon Map"
@@ -342,7 +351,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "32",
+   "id": "33",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -353,7 +362,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "33",
+   "id": "34",
    "metadata": {},
    "source": [
     "### Customizing Polygon Symbology"
@@ -362,7 +371,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "34",
+   "id": "35",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -378,7 +387,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "35",
+   "id": "36",
    "metadata": {},
    "source": [
     "### Creating Choropleth Maps"
@@ -387,7 +396,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "36",
+   "id": "37",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -398,7 +407,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "37",
+   "id": "38",
    "metadata": {},
    "source": [
     "### Creating 3D Extrusion Maps"
@@ -407,7 +416,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "38",
+   "id": "39",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -426,7 +435,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "39",
+   "id": "40",
    "metadata": {},
    "source": [
     "## Key Takeaways\n",
@@ -439,14 +448,14 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "40",
+   "id": "41",
    "metadata": {},
    "outputs": [],
    "source": []
   },
   {
    "cell_type": "markdown",
-   "id": "41",
+   "id": "42",
    "metadata": {},
    "source": [
     "### Exercise 2: Attribute-Based Filtering and Visualization"
@@ -455,14 +464,14 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "42",
+   "id": "43",
    "metadata": {},
    "outputs": [],
    "source": []
   },
   {
    "cell_type": "markdown",
-   "id": "43",
+   "id": "44",
    "metadata": {},
    "source": [
     "### Exercise 3: Line Network Visualization"
@@ -471,14 +480,14 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "44",
+   "id": "45",
    "metadata": {},
    "outputs": [],
    "source": []
   },
   {
    "cell_type": "markdown",
-   "id": "45",
+   "id": "46",
    "metadata": {},
    "source": [
     "### Exercise 4: Basic Polygon Visualization"
@@ -487,14 +496,14 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "46",
+   "id": "47",
    "metadata": {},
    "outputs": [],
    "source": []
   },
   {
    "cell_type": "markdown",
-   "id": "47",
+   "id": "48",
    "metadata": {},
    "source": [
     "### Exercise 5: Choropleth Mapping"
@@ -503,14 +512,14 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "48",
+   "id": "49",
    "metadata": {},
    "outputs": [],
    "source": []
   },
   {
    "cell_type": "markdown",
-   "id": "49",
+   "id": "50",
    "metadata": {},
    "source": [
     "### Exercise 6: Custom Choropleth Color Schemes"
@@ -519,14 +528,14 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "50",
+   "id": "51",
    "metadata": {},
    "outputs": [],
    "source": []
   },
   {
    "cell_type": "markdown",
-   "id": "51",
+   "id": "52",
    "metadata": {},
    "source": [
     "### Exercise 7: 3D Extrusion Visualization"
@@ -535,14 +544,14 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "52",
+   "id": "53",
    "metadata": {},
    "outputs": [],
    "source": []
   },
   {
    "cell_type": "markdown",
-   "id": "53",
+   "id": "54",
    "metadata": {},
    "source": [
     "### Exercise 8: Multi-Layer Visualization"
@@ -551,14 +560,14 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "54",
+   "id": "55",
    "metadata": {},
    "outputs": [],
    "source": []
   },
   {
    "cell_type": "markdown",
-   "id": "55",
+   "id": "56",
    "metadata": {},
    "source": [
     "### Exercise 9: Spatial Query Visualization"
@@ -567,14 +576,14 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "56",
+   "id": "57",
    "metadata": {},
    "outputs": [],
    "source": []
   },
   {
    "cell_type": "markdown",
-   "id": "57",
+   "id": "58",
    "metadata": {},
    "source": [
     "### Exercise 10: Custom Analysis and Visualization Pipeline"
@@ -583,7 +592,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "58",
+   "id": "59",
    "metadata": {},
    "outputs": [],
    "source": []

--- a/book/spatial/data-viz.md
+++ b/book/spatial/data-viz.md
@@ -10,6 +10,10 @@ kernelspec:
   language: python
   name: python3
 ---
+
+[![image](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/giswqs/duckdb-spatial/blob/main/book/spatial/data-viz.ipynb)
+[![image](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/giswqs/duckdb-spatial/main?urlpath=lab/tree/book/spatial/data-viz.ipynb)
+
 # Interactive Data Visualization
 
 ## Introduction

--- a/book/spatial/geometries.ipynb
+++ b/book/spatial/geometries.ipynb
@@ -5,6 +5,15 @@
    "id": "0",
    "metadata": {},
    "source": [
+    "[![image](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/giswqs/duckdb-spatial/blob/main/book/spatial/geometries.ipynb)\n",
+    "[![image](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/giswqs/duckdb-spatial/main?urlpath=lab/tree/book/spatial/geometries.ipynb)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1",
+   "metadata": {},
+   "source": [
     "# Geometry Operations and Functions\n",
     "\n",
     "## Introduction\n",
@@ -19,7 +28,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "1",
+   "id": "2",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -28,7 +37,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "2",
+   "id": "3",
    "metadata": {},
    "source": [
     "### Library Import and Configuration"
@@ -37,7 +46,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "3",
+   "id": "4",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -48,7 +57,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "4",
+   "id": "5",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -57,7 +66,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "5",
+   "id": "6",
    "metadata": {},
    "source": [
     "### Downloading the Sample Data"
@@ -66,7 +75,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "6",
+   "id": "7",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -76,7 +85,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "7",
+   "id": "8",
    "metadata": {},
    "source": [
     "## Connecting to DuckDB and Loading Extensions"
@@ -85,7 +94,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "8",
+   "id": "9",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -94,7 +103,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "9",
+   "id": "10",
    "metadata": {},
    "source": [
     "### Installing and Loading the Spatial Extension"
@@ -103,7 +112,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "10",
+   "id": "11",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -113,20 +122,10 @@
   },
   {
    "cell_type": "markdown",
-   "id": "11",
+   "id": "12",
    "metadata": {},
    "source": [
     "### Exploring the Database Contents"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "12",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "con.sql(\"SHOW TABLES;\")"
    ]
   },
   {
@@ -136,12 +135,22 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "con.sql(\"SHOW TABLES;\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "14",
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "con.sql(\"SELECT * FROM nyc_subway_stations LIMIT 5;\")"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "14",
+   "id": "15",
    "metadata": {},
    "source": [
     "## Understanding Geometry Types\n",
@@ -152,7 +161,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "15",
+   "id": "16",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -172,7 +181,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "16",
+   "id": "17",
    "metadata": {},
    "source": [
     "### Converting Geometries to Readable Text"
@@ -181,7 +190,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "17",
+   "id": "18",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -190,7 +199,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "18",
+   "id": "19",
    "metadata": {},
    "source": [
     "### Exporting Sample Geometries"
@@ -199,7 +208,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "19",
+   "id": "20",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -210,7 +219,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "20",
+   "id": "21",
    "metadata": {},
    "source": [
     "## Working with Points\n",
@@ -221,7 +230,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "21",
+   "id": "22",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -234,7 +243,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "22",
+   "id": "23",
    "metadata": {},
    "source": [
     "### Extracting Coordinate Values"
@@ -243,7 +252,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "23",
+   "id": "24",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -258,7 +267,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "24",
+   "id": "25",
    "metadata": {},
    "source": [
     "### Analyzing Real-World Point Data"
@@ -267,7 +276,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "25",
+   "id": "26",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -279,7 +288,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "26",
+   "id": "27",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -296,7 +305,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "27",
+   "id": "28",
    "metadata": {},
    "source": [
     "## Working with Linestrings\n",
@@ -307,7 +316,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "28",
+   "id": "29",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -320,7 +329,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "29",
+   "id": "30",
    "metadata": {},
    "source": [
     "### Extracting Linestring Properties"
@@ -329,7 +338,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "30",
+   "id": "31",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -342,7 +351,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "31",
+   "id": "32",
    "metadata": {},
    "source": [
     "## Working with Polygons\n",
@@ -353,7 +362,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "32",
+   "id": "33",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -366,7 +375,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "33",
+   "id": "34",
    "metadata": {},
    "source": [
     "### Analyzing Polygon Properties"
@@ -375,7 +384,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "34",
+   "id": "35",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -388,7 +397,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "35",
+   "id": "36",
    "metadata": {},
    "source": [
     "## Working with Collections\n",
@@ -399,7 +408,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "36",
+   "id": "37",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -412,7 +421,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "37",
+   "id": "38",
    "metadata": {},
    "source": [
     "## Visualizing NYC Spatial Data"
@@ -421,7 +430,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "38",
+   "id": "39",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -430,7 +439,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "39",
+   "id": "40",
    "metadata": {},
    "source": [
     "### Visualizing Subway Stations (Points)"
@@ -439,7 +448,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "40",
+   "id": "41",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -452,7 +461,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "41",
+   "id": "42",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -465,7 +474,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "42",
+   "id": "43",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -474,7 +483,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "43",
+   "id": "44",
    "metadata": {},
    "source": [
     "### Visualizing Streets (LineStrings)"
@@ -483,7 +492,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "44",
+   "id": "45",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -496,7 +505,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "45",
+   "id": "46",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -509,7 +518,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "46",
+   "id": "47",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -518,7 +527,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "47",
+   "id": "48",
    "metadata": {},
    "source": [
     "## Geometry Processing\n",
@@ -529,7 +538,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "48",
+   "id": "49",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -544,7 +553,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "49",
+   "id": "50",
    "metadata": {},
    "source": [
     "### Simplification and Envelopes"
@@ -553,7 +562,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "50",
+   "id": "51",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -568,7 +577,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "51",
+   "id": "52",
    "metadata": {},
    "source": [
     "### Overlay Operations"
@@ -577,7 +586,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "52",
+   "id": "53",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -596,7 +605,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "53",
+   "id": "54",
    "metadata": {},
    "source": [
     "## Geometry Validity and Robustness\n",
@@ -611,7 +620,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "54",
+   "id": "55",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -631,7 +640,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "55",
+   "id": "56",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -648,7 +657,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "56",
+   "id": "57",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -665,7 +674,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "57",
+   "id": "58",
    "metadata": {},
    "source": [
     "## Key Takeaways\n",
@@ -678,14 +687,14 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "58",
+   "id": "59",
    "metadata": {},
    "outputs": [],
    "source": []
   },
   {
    "cell_type": "markdown",
-   "id": "59",
+   "id": "60",
    "metadata": {},
    "source": [
     "### Exercise 2: Extracting Coordinate Information"
@@ -694,14 +703,14 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "60",
+   "id": "61",
    "metadata": {},
    "outputs": [],
    "source": []
   },
   {
    "cell_type": "markdown",
-   "id": "61",
+   "id": "62",
    "metadata": {},
    "source": [
     "### Exercise 3: Measuring Polygon Properties"
@@ -710,14 +719,14 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "62",
+   "id": "63",
    "metadata": {},
    "outputs": [],
    "source": []
   },
   {
    "cell_type": "markdown",
-   "id": "63",
+   "id": "64",
    "metadata": {},
    "source": [
     "### Exercise 4: Creating Buffers for Proximity Analysis"
@@ -726,14 +735,14 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "64",
+   "id": "65",
    "metadata": {},
    "outputs": [],
    "source": []
   },
   {
    "cell_type": "markdown",
-   "id": "65",
+   "id": "66",
    "metadata": {},
    "source": [
     "### Exercise 5: Geometry Type Inspection"
@@ -742,14 +751,14 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "66",
+   "id": "67",
    "metadata": {},
    "outputs": [],
    "source": []
   },
   {
    "cell_type": "markdown",
-   "id": "67",
+   "id": "68",
    "metadata": {},
    "source": [
     "### Exercise 6: Simplifying Complex Geometries"
@@ -758,14 +767,14 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "68",
+   "id": "69",
    "metadata": {},
    "outputs": [],
    "source": []
   },
   {
    "cell_type": "markdown",
-   "id": "69",
+   "id": "70",
    "metadata": {},
    "source": [
     "### Exercise 7: Calculating Distances Between Features"
@@ -774,14 +783,14 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "70",
+   "id": "71",
    "metadata": {},
    "outputs": [],
    "source": []
   },
   {
    "cell_type": "markdown",
-   "id": "71",
+   "id": "72",
    "metadata": {},
    "source": [
     "### Exercise 8: Performing Overlay Operations"
@@ -790,14 +799,14 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "72",
+   "id": "73",
    "metadata": {},
    "outputs": [],
    "source": []
   },
   {
    "cell_type": "markdown",
-   "id": "73",
+   "id": "74",
    "metadata": {},
    "source": [
     "### Exercise 9: Validating and Repairing Geometries"
@@ -806,14 +815,14 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "74",
+   "id": "75",
    "metadata": {},
    "outputs": [],
    "source": []
   },
   {
    "cell_type": "markdown",
-   "id": "75",
+   "id": "76",
    "metadata": {},
    "source": [
     "### Exercise 10: Practical Integration Challenge"
@@ -822,7 +831,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "76",
+   "id": "77",
    "metadata": {},
    "outputs": [],
    "source": []

--- a/book/spatial/geometries.md
+++ b/book/spatial/geometries.md
@@ -10,6 +10,10 @@ kernelspec:
   language: python
   name: python3
 ---
+
+[![image](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/giswqs/duckdb-spatial/blob/main/book/spatial/geometries.ipynb)
+[![image](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/giswqs/duckdb-spatial/main?urlpath=lab/tree/book/spatial/geometries.ipynb)
+
 # Geometry Operations and Functions
 
 ## Introduction

--- a/book/spatial/pmtiles.ipynb
+++ b/book/spatial/pmtiles.ipynb
@@ -5,6 +5,15 @@
    "id": "0",
    "metadata": {},
    "source": [
+    "[![image](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/giswqs/duckdb-spatial/blob/main/book/spatial/pmtiles.ipynb)\n",
+    "[![image](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/giswqs/duckdb-spatial/main?urlpath=lab/tree/book/spatial/pmtiles.ipynb)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1",
+   "metadata": {},
+   "source": [
     "# Working with Vector Tiles and PMTiles\n",
     "\n",
     "## Introduction\n",
@@ -19,7 +28,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "1",
+   "id": "2",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -29,7 +38,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "2",
+   "id": "3",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -39,7 +48,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "3",
+   "id": "4",
    "metadata": {},
    "source": [
     "## Visualizing Vector Tiles Directly from Files\n",
@@ -50,7 +59,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "4",
+   "id": "5",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -59,7 +68,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "5",
+   "id": "6",
    "metadata": {},
    "source": [
     "### Visualizing Data from Vector Files"
@@ -68,7 +77,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "6",
+   "id": "7",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -79,7 +88,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "7",
+   "id": "8",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -101,7 +110,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "8",
+   "id": "9",
    "metadata": {},
    "source": [
     "### Visualizing Data from Existing DuckDB Databases"
@@ -110,7 +119,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "9",
+   "id": "10",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -121,7 +130,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "10",
+   "id": "11",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -132,7 +141,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "11",
+   "id": "12",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -143,7 +152,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "12",
+   "id": "13",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -153,7 +162,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "13",
+   "id": "14",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -163,7 +172,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "14",
+   "id": "15",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -187,7 +196,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "15",
+   "id": "16",
    "metadata": {},
    "source": [
     "## Converting Vector Data to PMTiles\n",
@@ -200,7 +209,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "16",
+   "id": "17",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -212,7 +221,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "17",
+   "id": "18",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -233,7 +242,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "18",
+   "id": "19",
    "metadata": {},
    "source": [
     "## Visualizing PMTiles\n",
@@ -244,7 +253,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "19",
+   "id": "20",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -254,7 +263,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "20",
+   "id": "21",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -276,7 +285,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "21",
+   "id": "22",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -285,7 +294,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "22",
+   "id": "23",
    "metadata": {},
    "source": [
     "### Visualizing Cloud-Hosted PMTiles"
@@ -294,7 +303,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "23",
+   "id": "24",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -305,7 +314,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "24",
+   "id": "25",
    "metadata": {},
    "source": [
     "### Creating 3D Building Visualizations"
@@ -314,7 +323,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "25",
+   "id": "26",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -383,7 +392,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "26",
+   "id": "27",
    "metadata": {},
    "source": [
     "### Simplified 3D Building Visualization"
@@ -392,7 +401,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "27",
+   "id": "28",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -409,7 +418,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "28",
+   "id": "29",
    "metadata": {},
    "source": [
     "### Visualizing 2D Building Footprints"
@@ -418,7 +427,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "29",
+   "id": "30",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -432,7 +441,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "30",
+   "id": "31",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -445,7 +454,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "31",
+   "id": "32",
    "metadata": {},
    "source": [
     "### Visualizing Overture Transportation Networks"
@@ -454,7 +463,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "32",
+   "id": "33",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -466,7 +475,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "33",
+   "id": "34",
    "metadata": {},
    "source": [
     "### Visualizing Overture Places"
@@ -475,7 +484,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "34",
+   "id": "35",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -487,7 +496,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "35",
+   "id": "36",
    "metadata": {},
    "source": [
     "## Key Takeaways\n",
@@ -500,14 +509,14 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "36",
+   "id": "37",
    "metadata": {},
    "outputs": [],
    "source": []
   },
   {
    "cell_type": "markdown",
-   "id": "37",
+   "id": "38",
    "metadata": {},
    "source": [
     "### Exercise 2: Visualizing Data from DuckDB Database"
@@ -516,14 +525,14 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "38",
+   "id": "39",
    "metadata": {},
    "outputs": [],
    "source": []
   },
   {
    "cell_type": "markdown",
-   "id": "39",
+   "id": "40",
    "metadata": {},
    "source": [
     "### Exercise 3: Converting Spatial Data to PMTiles"
@@ -532,14 +541,14 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "40",
+   "id": "41",
    "metadata": {},
    "outputs": [],
    "source": []
   },
   {
    "cell_type": "markdown",
-   "id": "41",
+   "id": "42",
    "metadata": {},
    "source": [
     "### Exercise 4: Serving and Visualizing Local PMTiles"
@@ -548,14 +557,14 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "42",
+   "id": "43",
    "metadata": {},
    "outputs": [],
    "source": []
   },
   {
    "cell_type": "markdown",
-   "id": "43",
+   "id": "44",
    "metadata": {},
    "source": [
     "### Exercise 5: Exporting NYC Data to PMTiles"
@@ -564,14 +573,14 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "44",
+   "id": "45",
    "metadata": {},
    "outputs": [],
    "source": []
   },
   {
    "cell_type": "markdown",
-   "id": "45",
+   "id": "46",
    "metadata": {},
    "source": [
     "### Exercise 6: Multi-Layer PMTiles Visualization"
@@ -580,14 +589,14 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "46",
+   "id": "47",
    "metadata": {},
    "outputs": [],
    "source": []
   },
   {
    "cell_type": "markdown",
-   "id": "47",
+   "id": "48",
    "metadata": {},
    "source": [
     "### Exercise 7: Visualizing Cloud-Hosted Overture Data"
@@ -596,14 +605,14 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "48",
+   "id": "49",
    "metadata": {},
    "outputs": [],
    "source": []
   },
   {
    "cell_type": "markdown",
-   "id": "49",
+   "id": "50",
    "metadata": {},
    "source": [
     "### Exercise 8: Custom 3D Building Visualization"
@@ -612,14 +621,14 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "50",
+   "id": "51",
    "metadata": {},
    "outputs": [],
    "source": []
   },
   {
    "cell_type": "markdown",
-   "id": "51",
+   "id": "52",
    "metadata": {},
    "source": [
     "### Exercise 9: Overture Transportation Network Analysis"
@@ -628,14 +637,14 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "52",
+   "id": "53",
    "metadata": {},
    "outputs": [],
    "source": []
   },
   {
    "cell_type": "markdown",
-   "id": "53",
+   "id": "54",
    "metadata": {},
    "source": [
     "### Exercise 10: Complete Spatial Analysis to PMTiles Workflow"
@@ -644,7 +653,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "54",
+   "id": "55",
    "metadata": {},
    "outputs": [],
    "source": []

--- a/book/spatial/pmtiles.md
+++ b/book/spatial/pmtiles.md
@@ -10,6 +10,10 @@ kernelspec:
   language: python
   name: python3
 ---
+
+[![image](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/giswqs/duckdb-spatial/blob/main/book/spatial/pmtiles.ipynb)
+[![image](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/giswqs/duckdb-spatial/main?urlpath=lab/tree/book/spatial/pmtiles.ipynb)
+
 # Working with Vector Tiles and PMTiles
 
 ## Introduction

--- a/book/spatial/spatial-joins.ipynb
+++ b/book/spatial/spatial-joins.ipynb
@@ -5,6 +5,15 @@
    "id": "0",
    "metadata": {},
    "source": [
+    "[![image](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/giswqs/duckdb-spatial/blob/main/book/spatial/spatial-joins.ipynb)\n",
+    "[![image](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/giswqs/duckdb-spatial/main?urlpath=lab/tree/book/spatial/spatial-joins.ipynb)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1",
+   "metadata": {},
+   "source": [
     "# Advanced Spatial Joins\n",
     "\n",
     "## Introduction\n",
@@ -19,7 +28,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "1",
+   "id": "2",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -28,7 +37,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "2",
+   "id": "3",
    "metadata": {},
    "source": [
     "## Library Import and Configuration"
@@ -37,7 +46,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "3",
+   "id": "4",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -48,7 +57,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "4",
+   "id": "5",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -58,7 +67,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "5",
+   "id": "6",
    "metadata": {},
    "source": [
     "## Connecting to DuckDB"
@@ -67,7 +76,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "6",
+   "id": "7",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -76,7 +85,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "7",
+   "id": "8",
    "metadata": {},
    "source": [
     "### Loading the Spatial Extension"
@@ -85,7 +94,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "8",
+   "id": "9",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -95,7 +104,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "9",
+   "id": "10",
    "metadata": {},
    "source": [
     "### Exploring the Database Contents"
@@ -104,7 +113,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "10",
+   "id": "11",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -113,7 +122,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "11",
+   "id": "12",
    "metadata": {},
    "source": [
     "## Intersection Joins\n",
@@ -124,7 +133,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "12",
+   "id": "13",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -134,7 +143,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "13",
+   "id": "14",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -143,7 +152,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "14",
+   "id": "15",
    "metadata": {},
    "source": [
     "### Performing a Basic Spatial Join"
@@ -152,7 +161,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "15",
+   "id": "16",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -170,7 +179,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "16",
+   "id": "17",
    "metadata": {},
    "source": [
     "### Scaling to All Features"
@@ -179,7 +188,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "17",
+   "id": "18",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -196,7 +205,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "18",
+   "id": "19",
    "metadata": {},
    "source": [
     "### Combining Spatial and Attribute Filters"
@@ -205,7 +214,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "19",
+   "id": "20",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -217,7 +226,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "20",
+   "id": "21",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -235,7 +244,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "21",
+   "id": "22",
    "metadata": {},
    "source": [
     "### Pattern Summary for Point-in-Polygon Joins\n",
@@ -250,7 +259,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "22",
+   "id": "23",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -260,7 +269,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "23",
+   "id": "24",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -276,7 +285,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "24",
+   "id": "25",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -288,7 +297,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "25",
+   "id": "26",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -302,7 +311,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "26",
+   "id": "27",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -320,7 +329,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "27",
+   "id": "28",
    "metadata": {},
    "source": [
     "## Advanced Join"
@@ -329,7 +338,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "28",
+   "id": "29",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -346,7 +355,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "29",
+   "id": "30",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -368,7 +377,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "30",
+   "id": "31",
    "metadata": {},
    "source": [
     "## Coordinate System Transformations\n",
@@ -379,7 +388,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "31",
+   "id": "32",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -389,7 +398,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "32",
+   "id": "33",
    "metadata": {},
    "source": [
     "### Applying the Transformation"
@@ -398,7 +407,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "33",
+   "id": "34",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -409,7 +418,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "34",
+   "id": "35",
    "metadata": {},
    "source": [
     "### When and How to Use ST_Transform\n",
@@ -420,7 +429,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "35",
+   "id": "36",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -440,7 +449,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "36",
+   "id": "37",
    "metadata": {},
    "source": [
     "## Spatial Relationship Functions Reference\n",
@@ -459,14 +468,14 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "37",
+   "id": "38",
    "metadata": {},
    "outputs": [],
    "source": []
   },
   {
    "cell_type": "markdown",
-   "id": "38",
+   "id": "39",
    "metadata": {},
    "source": [
     "### Exercise 2: Distance-Based Proximity Join with Aggregation"
@@ -475,14 +484,14 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "39",
+   "id": "40",
    "metadata": {},
    "outputs": [],
    "source": []
   },
   {
    "cell_type": "markdown",
-   "id": "40",
+   "id": "41",
    "metadata": {},
    "source": [
     "### Exercise 3: Finding Nearest Features with Distance Calculation"
@@ -491,14 +500,14 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "41",
+   "id": "42",
    "metadata": {},
    "outputs": [],
    "source": []
   },
   {
    "cell_type": "markdown",
-   "id": "42",
+   "id": "43",
    "metadata": {},
    "source": [
     "### Exercise 4: Multi-Table Join with Complex Filtering"
@@ -507,14 +516,14 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "43",
+   "id": "44",
    "metadata": {},
    "outputs": [],
    "source": []
   },
   {
    "cell_type": "markdown",
-   "id": "44",
+   "id": "45",
    "metadata": {},
    "source": [
     "### Exercise 5: Performance Analysis with Filtering Strategies"
@@ -523,14 +532,14 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "45",
+   "id": "46",
    "metadata": {},
    "outputs": [],
    "source": []
   },
   {
    "cell_type": "markdown",
-   "id": "46",
+   "id": "47",
    "metadata": {},
    "source": [
     "### Exercise 6: Demographic Analysis Across Multiple Transit Lines"
@@ -539,14 +548,14 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "47",
+   "id": "48",
    "metadata": {},
    "outputs": [],
    "source": []
   },
   {
    "cell_type": "markdown",
-   "id": "48",
+   "id": "49",
    "metadata": {},
    "source": [
     "### Exercise 7: Coordinate System Transformation Practice"
@@ -555,14 +564,14 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "49",
+   "id": "50",
    "metadata": {},
    "outputs": [],
    "source": []
   },
   {
    "cell_type": "markdown",
-   "id": "50",
+   "id": "51",
    "metadata": {},
    "source": [
     "### Exercise 8: Transit Accessibility Scoring"
@@ -571,7 +580,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "51",
+   "id": "52",
    "metadata": {},
    "outputs": [],
    "source": []

--- a/book/spatial/spatial-joins.md
+++ b/book/spatial/spatial-joins.md
@@ -10,6 +10,10 @@ kernelspec:
   language: python
   name: python3
 ---
+
+[![image](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/giswqs/duckdb-spatial/blob/main/book/spatial/spatial-joins.ipynb)
+[![image](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/giswqs/duckdb-spatial/main?urlpath=lab/tree/book/spatial/spatial-joins.ipynb)
+
 # Advanced Spatial Joins
 
 ## Introduction

--- a/book/spatial/spatial-relationships.ipynb
+++ b/book/spatial/spatial-relationships.ipynb
@@ -5,6 +5,15 @@
    "id": "0",
    "metadata": {},
    "source": [
+    "[![image](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/giswqs/duckdb-spatial/blob/main/book/spatial/spatial-relationships.ipynb)\n",
+    "[![image](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/giswqs/duckdb-spatial/main?urlpath=lab/tree/book/spatial/spatial-relationships.ipynb)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1",
+   "metadata": {},
+   "source": [
     "# Spatial Queries and Relationships\n",
     "\n",
     "## Introduction\n",
@@ -19,7 +28,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "1",
+   "id": "2",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -28,7 +37,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "2",
+   "id": "3",
    "metadata": {},
    "source": [
     "### Library Import and Configuration"
@@ -37,7 +46,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "3",
+   "id": "4",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -48,7 +57,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "4",
+   "id": "5",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -57,7 +66,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "5",
+   "id": "6",
    "metadata": {},
    "source": [
     "### Downloading the Sample Database"
@@ -66,7 +75,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "6",
+   "id": "7",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -76,7 +85,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "7",
+   "id": "8",
    "metadata": {},
    "source": [
     "## Connecting to DuckDB and Loading Extensions"
@@ -85,7 +94,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "8",
+   "id": "9",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -94,7 +103,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "9",
+   "id": "10",
    "metadata": {},
    "source": [
     "### Installing and Loading the Spatial Extension"
@@ -103,7 +112,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "10",
+   "id": "11",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -113,20 +122,10 @@
   },
   {
    "cell_type": "markdown",
-   "id": "11",
+   "id": "12",
    "metadata": {},
    "source": [
     "### Exploring the Database Structure"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "12",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "con.sql(\"SHOW TABLES;\")"
    ]
   },
   {
@@ -136,12 +135,22 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "con.sql(\"SHOW TABLES;\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "14",
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "con.sql(\"SELECT * from nyc_subway_stations LIMIT 5\")"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "14",
+   "id": "15",
    "metadata": {},
    "source": [
     "## Understanding Spatial Relationships\n",
@@ -154,7 +163,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "15",
+   "id": "16",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -168,7 +177,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "16",
+   "id": "17",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -181,7 +190,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "17",
+   "id": "18",
    "metadata": {},
    "source": [
     "### Practical Considerations for ST_Equals\n",
@@ -216,7 +225,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "18",
+   "id": "19",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -230,7 +239,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "19",
+   "id": "20",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -243,7 +252,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "20",
+   "id": "21",
    "metadata": {},
    "source": [
     "## Distance-Based Relationships\n",
@@ -256,7 +265,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "21",
+   "id": "22",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -269,7 +278,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "22",
+   "id": "23",
    "metadata": {},
    "source": [
     "### Distance with Real Data"
@@ -278,7 +287,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "23",
+   "id": "24",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -296,7 +305,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "24",
+   "id": "25",
    "metadata": {},
    "source": [
     "### Critical: Coordinate System Units Matter\n",
@@ -311,7 +320,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "25",
+   "id": "26",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -321,7 +330,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "26",
+   "id": "27",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -340,7 +349,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "27",
+   "id": "28",
    "metadata": {},
    "source": [
     "### When to Use ST_DWithin\n",
@@ -351,7 +360,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "28",
+   "id": "29",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -366,7 +375,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "29",
+   "id": "30",
    "metadata": {},
    "source": [
     "## Key Takeaways\n",
@@ -379,14 +388,14 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "30",
+   "id": "31",
    "metadata": {},
    "outputs": [],
    "source": []
   },
   {
    "cell_type": "markdown",
-   "id": "31",
+   "id": "32",
    "metadata": {},
    "source": [
     "### Exercise 2: Point-in-Polygon Analysis"
@@ -395,14 +404,14 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "32",
+   "id": "33",
    "metadata": {},
    "outputs": [],
    "source": []
   },
   {
    "cell_type": "markdown",
-   "id": "33",
+   "id": "34",
    "metadata": {},
    "source": [
     "### Exercise 3: Containment vs. Intersection"
@@ -411,14 +420,14 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "34",
+   "id": "35",
    "metadata": {},
    "outputs": [],
    "source": []
   },
   {
    "cell_type": "markdown",
-   "id": "35",
+   "id": "36",
    "metadata": {},
    "source": [
     "### Exercise 4: Distance Calculations"
@@ -427,14 +436,14 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "36",
+   "id": "37",
    "metadata": {},
    "outputs": [],
    "source": []
   },
   {
    "cell_type": "markdown",
-   "id": "37",
+   "id": "38",
    "metadata": {},
    "source": [
     "### Exercise 5: Proximity Filtering"
@@ -443,14 +452,14 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "38",
+   "id": "39",
    "metadata": {},
    "outputs": [],
    "source": []
   },
   {
    "cell_type": "markdown",
-   "id": "39",
+   "id": "40",
    "metadata": {},
    "source": [
     "### Exercise 6: Combining Multiple Spatial Criteria"
@@ -459,7 +468,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "40",
+   "id": "41",
    "metadata": {},
    "outputs": [],
    "source": []

--- a/book/spatial/spatial-relationships.md
+++ b/book/spatial/spatial-relationships.md
@@ -10,6 +10,10 @@ kernelspec:
   language: python
   name: python3
 ---
+
+[![image](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/giswqs/duckdb-spatial/blob/main/book/spatial/spatial-relationships.ipynb)
+[![image](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/giswqs/duckdb-spatial/main?urlpath=lab/tree/book/spatial/spatial-relationships.ipynb)
+
 # Spatial Queries and Relationships
 
 ## Introduction

--- a/index.md
+++ b/index.md
@@ -1,5 +1,10 @@
 # Spatial Data Management with DuckDB
 
+[![image](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/giswqs/duckdb-spatial/blob/main)
+[![image](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/giswqs/duckdb-spatial/HEAD)
+[![Amazon](https://img.shields.io/badge/Buy%20on-Amazon-orange?logo=amazon&logoColor=white)](https://www.amazon.com/dp/B0G2JFMFFC)
+[![YouTube](https://img.shields.io/badge/Watch-Video-red?logo=youtube&logoColor=white)](https://www.youtube.com/@giswqs)
+
 ## Introduction
 
 Welcome to the official website for **_Spatial Data Management with DuckDB: From SQL Basics to Advanced Geospatial Analytics_**. This website contains all the code examples featured in the book, designed to help you learn and apply DuckDB for geospatial analysis.

--- a/myst.yml
+++ b/myst.yml
@@ -10,12 +10,12 @@ project:
     - .DS_Store
     - "**.ipynb_checkpoints"
   github: giswqs/duckdb-spatial
-  thebe:
-    binder:
-      repo: giswqs/duckdb-spatial
-      provider: github
-      url: https://mybinder.org
-      ref: main
+  # thebe:
+  #   binder:
+  #     repo: giswqs/duckdb-spatial
+  #     provider: github
+  #     url: https://mybinder.org
+  #     ref: main
   bibliography:
     - book/references.bib
   toc:

--- a/scripts/add_colab_badge.py
+++ b/scripts/add_colab_badge.py
@@ -1,0 +1,244 @@
+#!/usr/bin/env python3
+"""Add Google Colab and Binder launch badges to chapter pages and notebooks.
+
+Inserts a Colab + Binder badge block near the top of every chapter Markdown
+file that has a sibling Jupyter notebook, and prepends a matching badge cell
+to every notebook under the book directory. Each badge deep-links to the
+specific ``.ipynb``:
+
+* Colab: ``colab.research.google.com/github/<owner>/<repo>/blob/<branch>/<path>``
+* Binder: ``mybinder.org/v2/gh/<owner>/<repo>/<branch>?urlpath=lab/tree/<path>``
+
+The script is idempotent: a file already containing either badge is left
+unchanged. By default the GitHub slug is read from ``project.github`` in
+``myst.yml``.
+
+Usage:
+    python scripts/add_colab_badge.py --dry-run
+    python scripts/add_colab_badge.py
+    python scripts/add_colab_badge.py --repo giswqs/GeoAI-Book --branch main
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+import nbformat
+
+COLAB_BADGE_SVG = "https://colab.research.google.com/assets/colab-badge.svg"
+BINDER_BADGE_SVG = "https://mybinder.org/badge_logo.svg"
+COLAB_OPEN_PREFIX = "https://colab.research.google.com/github/"
+BINDER_OPEN_PREFIX = "https://mybinder.org/v2/gh/"
+FRONTMATTER_RE = re.compile(r"\A---\n.*?\n---\n", re.DOTALL)
+
+
+def make_badges(repo: str, branch: str, notebook_path: str) -> str:
+    """Return the Markdown snippet for the Colab and Binder launch badges.
+
+    Args:
+        repo: GitHub ``owner/name`` slug.
+        branch: Branch or ref to link to.
+        notebook_path: Repo-relative POSIX path to the ``.ipynb`` file.
+
+    Returns:
+        A two-line Markdown block: one badge per line.
+    """
+    colab_url = f"{COLAB_OPEN_PREFIX}{repo}/blob/{branch}/{notebook_path}"
+    binder_url = f"{BINDER_OPEN_PREFIX}{repo}/{branch}?urlpath=lab/tree/{notebook_path}"
+    return (
+        f"[![image]({COLAB_BADGE_SVG})]({colab_url})\n"
+        f"[![image]({BINDER_BADGE_SVG})]({binder_url})"
+    )
+
+
+def has_launch_badge(text: str) -> bool:
+    """Return True if ``text`` already contains a Colab or Binder badge."""
+    return COLAB_BADGE_SVG in text or BINDER_BADGE_SVG in text
+
+
+def insert_badges_into_markdown(md_text: str, badges: str) -> str:
+    """Insert ``badges`` after the YAML frontmatter, before the body.
+
+    Args:
+        md_text: Original Markdown content.
+        badges: Badge block to inject.
+
+    Returns:
+        New Markdown content with the badges inserted as their own paragraph.
+    """
+    match = FRONTMATTER_RE.match(md_text)
+    if match:
+        head = match.group(0)
+        rest = md_text[match.end() :].lstrip("\n")
+        return f"{head}\n{badges}\n\n{rest}"
+    return f"{badges}\n\n{md_text.lstrip()}"
+
+
+def process_markdown(
+    md_path: Path,
+    repo: str,
+    branch: str,
+    project_root: Path,
+    dry_run: bool,
+) -> str:
+    """Add Colab and Binder badges to a Markdown file paired with a notebook.
+
+    Args:
+        md_path: Markdown file to update.
+        repo: GitHub ``owner/name`` slug.
+        branch: Branch or ref to link to.
+        project_root: Repo root used to compute the relative notebook path.
+        dry_run: If True, do not write changes.
+
+    Returns:
+        One of ``"added"``, ``"skipped"``, ``"no-notebook"``.
+    """
+    nb_path = md_path.with_suffix(".ipynb")
+    if not nb_path.exists():
+        return "no-notebook"
+    text = md_path.read_text(encoding="utf-8")
+    if has_launch_badge(text):
+        return "skipped"
+    rel = nb_path.relative_to(project_root).as_posix()
+    new_text = insert_badges_into_markdown(text, make_badges(repo, branch, rel))
+    if not dry_run:
+        md_path.write_text(new_text, encoding="utf-8")
+    return "added"
+
+
+def process_notebook(
+    nb_path: Path,
+    repo: str,
+    branch: str,
+    project_root: Path,
+    dry_run: bool,
+) -> str:
+    """Prepend a Colab + Binder badge cell to a notebook.
+
+    Args:
+        nb_path: Notebook file to update.
+        repo: GitHub ``owner/name`` slug.
+        branch: Branch or ref to link to.
+        project_root: Repo root used to compute the relative notebook path.
+        dry_run: If True, do not write changes.
+
+    Returns:
+        ``"added"`` or ``"skipped"``.
+    """
+    nb = nbformat.read(nb_path, as_version=4)
+    existing = "\n".join(
+        cell.get("source", "")
+        for cell in nb.cells
+        if cell.get("cell_type") == "markdown"
+    )
+    if has_launch_badge(existing):
+        return "skipped"
+    rel = nb_path.relative_to(project_root).as_posix()
+    badge_cell = nbformat.v4.new_markdown_cell(make_badges(repo, branch, rel))
+    nb.cells.insert(0, badge_cell)
+    if not dry_run:
+        nbformat.write(nb, nb_path)
+    return "added"
+
+
+def repo_from_myst_yml(project_root: Path) -> str | None:
+    """Best-effort extraction of ``project.github`` from ``myst.yml``."""
+    p = project_root / "myst.yml"
+    if not p.exists():
+        return None
+    for line in p.read_text(encoding="utf-8").splitlines():
+        m = re.match(r"\s*github:\s*(\S+)", line)
+        if m:
+            slug = m.group(1).strip().strip("\"'")
+            slug = slug.removeprefix("https://github.com/").rstrip("/")
+            return slug
+    return None
+
+
+def parse_args() -> argparse.Namespace:
+    """Parse command-line arguments."""
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument(
+        "--root",
+        type=Path,
+        default=Path(__file__).resolve().parent.parent,
+        help="Project root (defaults to the repository root).",
+    )
+    parser.add_argument(
+        "--book-dir",
+        default="book",
+        help="Directory under root to scan (default: book).",
+    )
+    parser.add_argument(
+        "--repo",
+        default=None,
+        help="GitHub owner/repo slug (default: read from myst.yml).",
+    )
+    parser.add_argument(
+        "--branch",
+        default="main",
+        help="Branch or ref used in the Colab URL (default: main).",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Report planned changes without modifying any files.",
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    """Entry point. Returns a process exit code."""
+    args = parse_args()
+    root = args.root.resolve()
+    book = root / args.book_dir
+    if not book.is_dir():
+        print(f"error: {book} is not a directory", file=sys.stderr)
+        return 1
+
+    repo = args.repo or repo_from_myst_yml(root)
+    if not repo:
+        print(
+            "error: --repo not given and could not infer it from myst.yml",
+            file=sys.stderr,
+        )
+        return 1
+
+    md_results: dict[str, list[str]] = {
+        "added": [],
+        "skipped": [],
+        "no-notebook": [],
+    }
+    for md in sorted(book.rglob("*.md")):
+        outcome = process_markdown(md, repo, args.branch, root, args.dry_run)
+        md_results[outcome].append(md.relative_to(root).as_posix())
+
+    nb_results: dict[str, list[str]] = {"added": [], "skipped": []}
+    for nb in sorted(book.rglob("*.ipynb")):
+        if ".ipynb_checkpoints" in nb.parts:
+            continue
+        outcome = process_notebook(nb, repo, args.branch, root, args.dry_run)
+        nb_results[outcome].append(nb.relative_to(root).as_posix())
+
+    prefix = "[dry-run] " if args.dry_run else ""
+    print(
+        f"{prefix}Markdown: added={len(md_results['added'])}, "
+        f"skipped={len(md_results['skipped'])}, "
+        f"no-notebook={len(md_results['no-notebook'])}"
+    )
+    for path in md_results["added"]:
+        print(f"  + {path}")
+    print(
+        f"{prefix}Notebooks: added={len(nb_results['added'])}, "
+        f"skipped={len(nb_results['skipped'])}"
+    )
+    for path in nb_results["added"]:
+        print(f"  + {path}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
- Inserted Colab and Binder launch badges in `pmtiles.md`, `spatial-joins.md`, and `spatial-relationships.md` for easy access to interactive notebooks.
- Updated Jupyter notebooks (`spatial-joins.ipynb`, `spatial-relationships.ipynb`) to include corresponding badge cells at the top.
- Modified `index.md` to include Colab and Binder badges for the main project page.
- Created a script (`add_colab_badge.py`) to automate the addition of badges to markdown and notebook files, ensuring idempotency.
- Commented out the Thebe configuration in `myst.yml` for future reference.